### PR TITLE
Increase compiler warning levels and associated code changes

### DIFF
--- a/enum.h
+++ b/enum.h
@@ -195,7 +195,7 @@ _ENUM_CONSTEXPR size_t _default<size_t>()
 template <typename T>
 struct optional {
     _ENUM_CONSTEXPR optional() : _valid(false), _value(_default<T>()) { }
-    _ENUM_CONSTEXPR optional(T value) : _valid(true), _value(value) { }
+    _ENUM_CONSTEXPR optional(T v) : _valid(true), _value(v) { }
 
     _ENUM_CONSTEXPR const T& operator *() const { return _value; }
     _ENUM_CONSTEXPR const T& operator ->() const { return _value; }
@@ -221,8 +221,8 @@ template <typename EnumType>
 struct _eat_assign {
     explicit _ENUM_CONSTEXPR _eat_assign(EnumType value) : _value(value) { }
     template <typename Any>
-    _ENUM_CONSTEXPR EnumType operator =(Any dummy) const
-        { return _value; }
+    _ENUM_CONSTEXPR const _eat_assign& operator =(Any dummy) const
+        { return *this; }
     _ENUM_CONSTEXPR operator EnumType () const { return _value; }
 
   private:
@@ -239,8 +239,8 @@ struct _Iterable {
     _ENUM_CONSTEXPR const Element& operator [](size_t index) const
         { return _array[index]; }
 
-    _ENUM_CONSTEXPR _Iterable(const Element *array, size_t size) :
-        _array(array), _size(size) { };
+    _ENUM_CONSTEXPR _Iterable(const Element *array, size_t s) :
+        _array(array), _size(s) { };
 
   private:
     const Element * const   _array;
@@ -308,7 +308,7 @@ constexpr char _select(const char *from, size_t from_length, size_t index)
 
 constexpr char _toLowercaseAscii(char c)
 {
-    return c >= 0x41 && c <= 0x5A ? c + 0x20 : c;
+    return c >= 0x41 && c <= 0x5A ? (char) (c + 0x20) : c;
 }
 
 constexpr bool _namesMatch(const char *stringizedName,
@@ -496,7 +496,7 @@ enum class _Case : Integral { __VA_ARGS__ };                                   \
                                                                                \
 static_assert(_size > 0, "no constants defined in enum type");                 \
                                                                                \
-_ENUM_TRIM_STRINGS(__VA_ARGS__);                                               \
+_ENUM_TRIM_STRINGS(__VA_ARGS__)                                                \
                                                                                \
 constexpr const char * const    _name_array[] =                                \
     { _ENUM_REFER_TO_STRINGS(__VA_ARGS__) };                                   \
@@ -901,9 +901,9 @@ _ENUM_CONSTEXPR const EnumType operator +(_ENUM_NS(EnumType)::_Base base)      \
 
 
 #define ENUM(EnumType, Integral, ...)                                          \
-    _ENUM_DATA(EnumType, Integral, __VA_ARGS__);                               \
-    _ENUM_TYPE(EnumType, Integral, __VA_ARGS__);                               \
-    _ENUM_OPERATORS(EnumType);
+    _ENUM_DATA(EnumType, Integral, __VA_ARGS__)                                \
+    _ENUM_TYPE(EnumType, Integral, __VA_ARGS__)                                \
+    _ENUM_OPERATORS(EnumType)
 
 
 

--- a/example/1-basic.cc
+++ b/example/1-basic.cc
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <enum.h>
 
-ENUM(Channel, uint16_t, Red, Green = 2, Blue, Alias = Red);
+ENUM(Channel, uint16_t, Red, Green = 2, Blue, Alias = Red)
 
 // Enums should be treated like integers (in memory, Channel is a uint16_t), and
 // should generally be passed by value.

--- a/example/2-iterate.cc
+++ b/example/2-iterate.cc
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <enum.h>
 
-ENUM(Channel, int, Red = 3, Green = 4, Blue = 0);
+ENUM(Channel, int, Red = 3, Green = 4, Blue = 0)
 
 int main()
 {

--- a/example/3-switch.cc
+++ b/example/3-switch.cc
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <enum.h>
 
-ENUM(Channel, int, Red, Green, Blue);
+ENUM(Channel, int, Red, Green, Blue)
 
 void respond_to_channel(Channel channel)
 {

--- a/example/4-constexpr.cc
+++ b/example/4-constexpr.cc
@@ -6,7 +6,7 @@
 #include <iostream>
 #include <enum.h>
 
-ENUM(Channel, int, Red, Green = 2, Blue);
+ENUM(Channel, int, Red, Green = 2, Blue)
 
 // Initialization.
 constexpr Channel       channel_1 = Channel::Green;

--- a/example/5-containers.cc
+++ b/example/5-containers.cc
@@ -6,7 +6,7 @@
 
 #include <enum.h>
 
-ENUM(Channel, int, Red, Green, Blue);
+ENUM(Channel, int, Red, Green, Blue)
 
 int main()
 {

--- a/example/6-traits.cc
+++ b/example/6-traits.cc
@@ -27,11 +27,11 @@ constexpr const Enum default_()
 
 
 // Default will be Red, because it is first.
-ENUM(Channel, int, Red, Green, Blue);
+ENUM(Channel, int, Red, Green, Blue)
 
 // Default will be TrueColor, even though it is not first.
-ENUM(Depth, int, HighColor, TrueColor);
-ENUM_DEFAULT(Depth, TrueColor);
+ENUM(Depth, int, HighColor, TrueColor)
+ENUM_DEFAULT(Depth, TrueColor)
 
 
 

--- a/example/7-bitset.cc
+++ b/example/7-bitset.cc
@@ -15,7 +15,7 @@ constexpr Enum maximum(Enum accumulator = Enum::_values[0], size_t index = 1)
             maximum(accumulator, index + 1);
 }
 
-ENUM(Channel, int, Red, Green, Blue);
+ENUM(Channel, int, Red, Green, Blue)
 
 int main()
 {

--- a/example/8-constexpr-iterate.cc
+++ b/example/8-constexpr-iterate.cc
@@ -7,8 +7,8 @@
 #include <iostream>
 #include <enum.h>
 
-ENUM(Channel, int, Red, Green, Blue);
-ENUM(Depth, int, TrueColor, HighColor);
+ENUM(Channel, int, Red, Green, Blue)
+ENUM(Depth, int, TrueColor, HighColor)
 
 // Computes the length of a string.
 constexpr size_t string_length(const char *s, size_t index = 0)

--- a/test/cxxtest/tests.h
+++ b/test/cxxtest/tests.h
@@ -7,9 +7,9 @@
 
 
 
-ENUM(Channel, short, Red, Green, Blue);
-ENUM(Depth, short, HighColor = 40, TrueColor = 20);
-ENUM(Compression, short, None, Huffman, Default = Huffman);
+ENUM(Channel, short, Red, Green, Blue)
+ENUM(Depth, short, HighColor = 40, TrueColor = 20)
+ENUM(Compression, short, None, Huffman, Default = Huffman)
 
 
 

--- a/test/link/shared.h
+++ b/test/link/shared.h
@@ -3,6 +3,6 @@
 
 #include <enum.h>
 
-ENUM(Channel, int, Red, Green, Blue);
+ENUM(Channel, int, Red, Green, Blue)
 
 #endif // #ifndef _SHARED_H_

--- a/test/performance/4-declare_enums.cc
+++ b/test/performance/4-declare_enums.cc
@@ -1,22 +1,22 @@
 #include <enum.h>
 
 ENUM(Channel, int,
-     Red, Green, Blue, Cyan, Magenta, Yellow, Black, Hue, Saturation, Value);
+     Red, Green, Blue, Cyan, Magenta, Yellow, Black, Hue, Saturation, Value)
 
 ENUM(Direction, int,
      North, East, South, West, NorthEast, SouthEast, SouthWest, NorthWest,
      NorthNorthEast, EastNorthEast, EastSouthEast, SouthSouthEast,
-     SouthSouthWest, WestSouthWest, WestNorthWest, NorthNorthWest);
+     SouthSouthWest, WestSouthWest, WestNorthWest, NorthNorthWest)
 
 ENUM(ASTNode, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(State, int,
      Attacking, Defending, Searching, Pursuing, Hungry, Fleeing, Confused,
-     Healing, Stunned);
+     Healing, Stunned)
 
 ENUM(APIMethod, int,
      ReadPost, WritePost, PollPost, ReadImage, WriteImage, PollImage, ReadKey,
@@ -25,7 +25,7 @@ ENUM(APIMethod, int,
      ReadProject, WriteProject, PollProject, ReadComment, WriteComment,
      PollComment, ReadPermission, WritePermission, PollPermission, ReadOwner,
      WriteOwner, PollOwner, ReadProposal, WriteProposal, PollProposal,
-     ReadHistory, WriteHistory, PollHistory);
+     ReadHistory, WriteHistory, PollHistory)
 
 ENUM(Region, int,
      EasterEurope, CentralEurope, WesternEurope, Mediterranean, NorthAfrica,
@@ -38,7 +38,7 @@ ENUM(Region, int,
      HornOfAfrica, NearEast, AlSham, EastAfrica, NileBasin, Palestine, Levant,
      Anatolia, AegeanSea, GreatSteppe, CongoBasin, SouthAfrica, WestAfrica,
      Sahara, WestSahara, NorthwestTerritory, YukonAlaska, Quebec, NewEngland,
-     DeepSouth);
+     DeepSouth)
 
 int main()
 {
@@ -49,178 +49,178 @@ ENUM(ASTNode0, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode1, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode2, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode3, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode4, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode5, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode6, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode7, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode8, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode9, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode10, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode11, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode12, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode13, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode14, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode15, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode16, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode17, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode18, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode19, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode20, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode21, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode22, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode23, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode24, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode25, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode26, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode27, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode28, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)
 
 ENUM(ASTNode29, int,
      IntegerLiteral, StringLiteral, CharacterLiteral, Variable, UnaryOperation,
      BinaryOperation, ApplicationExpression, Abstraction, LetBinding,
      CaseExpression, Pattern, Signature, Module, Functor, TypeVariable,
-     BasicType, ArrowType, VariantTypeConstant);
+     BasicType, ArrowType, VariantTypeConstant)


### PR DESCRIPTION
Thanks for Better Enums. It's incredibly useful.

Some projects wishing to include ``enum.h`` might be following the advice of enabling all available compiler warning flags (eg C++ Coding Standards by Herb Sutter and Andrei Alexandrescu, Item #1, "Compile cleanly at high warning levels"). Such projects currently need to either modify ``enum.h`` or use ``#pragm`` directives to disable warnings for that file.

This PR modifies the example and test ``Makefile`` to enable all available warning flags, along with associated code changes to comply with the resulting compiler warnings. This allows ``enum.h`` to be directly used in projects without editing or ``#pragma`` directives. The test cases pass and the examples execute without error.