### PR TITLE
Only apply the cygwin fix on windows

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -245,15 +245,15 @@ def main():
     cxxtest_headers = " ".join(glob.glob(os.path.join("cxxtest", "*.h")))
     run("cxxtestgen --error-printer -o %s %s" %
         (CXXTEST_GENERATED, cxxtest_headers))
-    cygwin_fix_command = \
-        ("sed 's#\"/home#\"C:/cygwin/home#g' %s > $$$$ ; " + \
-        "mv $$$$ %s") % (CXXTEST_GENERATED, CXXTEST_GENERATED)
-    os.system(cygwin_fix_command)
 
     if re.search("Windows|CYGWIN", platform.system()) != None:
         full = windows_configurations
         default = windows_default
         windows = True
+        cygwin_fix_command = \
+            ("sed 's#\"/home#\"C:/cygwin/home#g' %s > $$$$ ; " + \
+            "mv $$$$ %s") % (CXXTEST_GENERATED, CXXTEST_GENERATED)
+        os.system(cygwin_fix_command)
     else:
         full = unix_configurations
         default = unix_default


### PR DESCRIPTION
The so called 'cygwin_fix_command' replaces all instances of '/home'
with 'C:/cygwin/home'. This will cause the tests to fail on linux as
this directory does not exist there.

I could not check if the test still works on windows after the fix.