### PR TITLE
Fixed "macro name is a reserved identifier" clang warning

### DIFF
--- a/enum.h
+++ b/enum.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#ifndef BETTER_ENUMS__ENUM_H
-#define BETTER_ENUMS__ENUM_H
+#ifndef BETTER_ENUMS_ENUM_H
+#define BETTER_ENUMS_ENUM_H
 
 
 
@@ -20,39 +20,39 @@
 #ifdef __GNUC__
 #   ifdef __clang__
 #       if __has_feature(cxx_constexpr)
-#           define BETTER_ENUMS__HAVE_CONSTEXPR
+#           define BETTER_ENUMS_HAVE_CONSTEXPR
 #       endif
 #       if !defined(__EXCEPTIONS) || !__has_feature(cxx_exceptions)
-#           define BETTER_ENUMS__NO_EXCEPTIONS
+#           define BETTER_ENUMS_NO_EXCEPTIONS
 #       endif
 #   else
 #       if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L
 #           if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 6))
-#               define BETTER_ENUMS__HAVE_CONSTEXPR
+#               define BETTER_ENUMS_HAVE_CONSTEXPR
 #           endif
 #       endif
 #       ifndef __EXCEPTIONS
-#           define BETTER_ENUMS__NO_EXCEPTIONS
+#           define BETTER_ENUMS_NO_EXCEPTIONS
 #       endif
 #   endif
 #endif
 
 #ifdef _MSC_VER
 #   ifndef _CPPUNWIND
-#       define BETTER_ENUMS__NO_EXCEPTIONS
+#       define BETTER_ENUMS_NO_EXCEPTIONS
 #   endif
 #   if _MSC_VER < 1600
-#       define BETTER_ENUMS__VC2008_WORKAROUNDS
+#       define BETTER_ENUMS_VC2008_WORKAROUNDS
 #   endif
 #endif
 
 #ifdef BETTER_ENUMS_CONSTEXPR
-#   define BETTER_ENUMS__HAVE_CONSTEXPR
+#   define BETTER_ENUMS_HAVE_CONSTEXPR
 #endif
 
 #ifdef BETTER_ENUMS_NO_CONSTEXPR
-#   ifdef BETTER_ENUMS__HAVE_CONSTEXPR
-#       undef BETTER_ENUMS__HAVE_CONSTEXPR
+#   ifdef BETTER_ENUMS_HAVE_CONSTEXPR
+#       undef BETTER_ENUMS_HAVE_CONSTEXPR
 #   endif
 #endif
 
@@ -64,24 +64,24 @@
 // nullptr is also available in Visual C++, but constexpr isn't. This
 // imprecision doesn't matter, however, because VC++ doesn't have the warnings
 // that make using nullptr necessary.
-#ifdef BETTER_ENUMS__HAVE_CONSTEXPR
-#   define BETTER_ENUMS__CONSTEXPR      constexpr
-#   define BETTER_ENUMS__NULLPTR        nullptr
+#ifdef BETTER_ENUMS_HAVE_CONSTEXPR
+#   define BETTER_ENUMS_CONSTEXPR      constexpr
+#   define BETTER_ENUMS_NULLPTR        nullptr
 #else
-#   define BETTER_ENUMS__CONSTEXPR
-#   define BETTER_ENUMS__NULLPTR        NULL
+#   define BETTER_ENUMS_CONSTEXPR
+#   define BETTER_ENUMS_NULLPTR        NULL
 #endif
 
-#ifndef BETTER_ENUMS__NO_EXCEPTIONS
-#   define BETTER_ENUMS__IF_EXCEPTIONS(x) x
+#ifndef BETTER_ENUMS_NO_EXCEPTIONS
+#   define BETTER_ENUMS_IF_EXCEPTIONS(x) x
 #else
-#   define BETTER_ENUMS__IF_EXCEPTIONS(x)
+#   define BETTER_ENUMS_IF_EXCEPTIONS(x)
 #endif
 
 #ifdef __GNUC__
-#   define BETTER_ENUMS__UNUSED(x) x __attribute__((__unused__))
+#   define BETTER_ENUMS_UNUSED(x) x __attribute__((__unused__))
 #else
-#   define BETTER_ENUMS__UNUSED(x) x
+#   define BETTER_ENUMS_UNUSED(x) x
 #endif
 
 
@@ -92,161 +92,161 @@
 #   include BETTER_ENUMS_MACRO_FILE
 #else
 
-#define BETTER_ENUMS__PP_MAP(macro, data, ...) \
-    BETTER_ENUMS__ID( \
-        BETTER_ENUMS__APPLY( \
-            BETTER_ENUMS__PP_MAP_VAR_COUNT, \
-            BETTER_ENUMS__PP_COUNT(__VA_ARGS__)) \
+#define BETTER_ENUMS_PP_MAP(macro, data, ...) \
+    BETTER_ENUMS_ID( \
+        BETTER_ENUMS_APPLY( \
+            BETTER_ENUMS_PP_MAP_VAR_COUNT, \
+            BETTER_ENUMS_PP_COUNT(__VA_ARGS__)) \
         (macro, data, __VA_ARGS__))
 
-#define BETTER_ENUMS__PP_MAP_VAR_COUNT(count) BETTER_ENUMS__M ## count
+#define BETTER_ENUMS_PP_MAP_VAR_COUNT(count) BETTER_ENUMS_M ## count
 
-#define BETTER_ENUMS__APPLY(macro, ...) BETTER_ENUMS__ID(macro(__VA_ARGS__))
+#define BETTER_ENUMS_APPLY(macro, ...) BETTER_ENUMS_ID(macro(__VA_ARGS__))
 
-#define BETTER_ENUMS__ID(x) x
+#define BETTER_ENUMS_ID(x) x
 
-#define BETTER_ENUMS__M1(m, d, x) m(d,0,x)
-#define BETTER_ENUMS__M2(m,d,x,...) m(d,1,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M1(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M3(m,d,x,...) m(d,2,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M2(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M4(m,d,x,...) m(d,3,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M3(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M5(m,d,x,...) m(d,4,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M4(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M6(m,d,x,...) m(d,5,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M5(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M7(m,d,x,...) m(d,6,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M6(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M8(m,d,x,...) m(d,7,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M7(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M9(m,d,x,...) m(d,8,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M8(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M10(m,d,x,...) m(d,9,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M9(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M11(m,d,x,...) m(d,10,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M10(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M12(m,d,x,...) m(d,11,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M11(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M13(m,d,x,...) m(d,12,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M12(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M14(m,d,x,...) m(d,13,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M13(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M15(m,d,x,...) m(d,14,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M14(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M16(m,d,x,...) m(d,15,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M15(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M17(m,d,x,...) m(d,16,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M16(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M18(m,d,x,...) m(d,17,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M17(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M19(m,d,x,...) m(d,18,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M18(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M20(m,d,x,...) m(d,19,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M19(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M21(m,d,x,...) m(d,20,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M20(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M22(m,d,x,...) m(d,21,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M21(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M23(m,d,x,...) m(d,22,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M22(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M24(m,d,x,...) m(d,23,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M23(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M25(m,d,x,...) m(d,24,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M24(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M26(m,d,x,...) m(d,25,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M25(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M27(m,d,x,...) m(d,26,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M26(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M28(m,d,x,...) m(d,27,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M27(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M29(m,d,x,...) m(d,28,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M28(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M30(m,d,x,...) m(d,29,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M29(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M31(m,d,x,...) m(d,30,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M30(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M32(m,d,x,...) m(d,31,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M31(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M33(m,d,x,...) m(d,32,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M32(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M34(m,d,x,...) m(d,33,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M33(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M35(m,d,x,...) m(d,34,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M34(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M36(m,d,x,...) m(d,35,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M35(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M37(m,d,x,...) m(d,36,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M36(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M38(m,d,x,...) m(d,37,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M37(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M39(m,d,x,...) m(d,38,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M38(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M40(m,d,x,...) m(d,39,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M39(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M41(m,d,x,...) m(d,40,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M40(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M42(m,d,x,...) m(d,41,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M41(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M43(m,d,x,...) m(d,42,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M42(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M44(m,d,x,...) m(d,43,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M43(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M45(m,d,x,...) m(d,44,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M44(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M46(m,d,x,...) m(d,45,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M45(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M47(m,d,x,...) m(d,46,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M46(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M48(m,d,x,...) m(d,47,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M47(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M49(m,d,x,...) m(d,48,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M48(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M50(m,d,x,...) m(d,49,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M49(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M51(m,d,x,...) m(d,50,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M50(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M52(m,d,x,...) m(d,51,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M51(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M53(m,d,x,...) m(d,52,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M52(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M54(m,d,x,...) m(d,53,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M53(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M55(m,d,x,...) m(d,54,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M54(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M56(m,d,x,...) m(d,55,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M55(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M57(m,d,x,...) m(d,56,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M56(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M58(m,d,x,...) m(d,57,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M57(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M59(m,d,x,...) m(d,58,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M58(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M60(m,d,x,...) m(d,59,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M59(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M61(m,d,x,...) m(d,60,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M60(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M62(m,d,x,...) m(d,61,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M61(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M63(m,d,x,...) m(d,62,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M62(m,d,__VA_ARGS__))
-#define BETTER_ENUMS__M64(m,d,x,...) m(d,63,x) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__M63(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M1(m, d, x) m(d,0,x)
+#define BETTER_ENUMS_M2(m,d,x,...) m(d,1,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M1(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M3(m,d,x,...) m(d,2,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M2(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M4(m,d,x,...) m(d,3,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M3(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M5(m,d,x,...) m(d,4,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M4(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M6(m,d,x,...) m(d,5,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M5(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M7(m,d,x,...) m(d,6,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M6(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M8(m,d,x,...) m(d,7,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M7(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M9(m,d,x,...) m(d,8,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M8(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M10(m,d,x,...) m(d,9,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M9(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M11(m,d,x,...) m(d,10,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M10(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M12(m,d,x,...) m(d,11,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M11(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M13(m,d,x,...) m(d,12,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M12(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M14(m,d,x,...) m(d,13,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M13(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M15(m,d,x,...) m(d,14,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M14(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M16(m,d,x,...) m(d,15,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M15(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M17(m,d,x,...) m(d,16,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M16(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M18(m,d,x,...) m(d,17,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M17(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M19(m,d,x,...) m(d,18,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M18(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M20(m,d,x,...) m(d,19,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M19(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M21(m,d,x,...) m(d,20,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M20(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M22(m,d,x,...) m(d,21,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M21(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M23(m,d,x,...) m(d,22,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M22(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M24(m,d,x,...) m(d,23,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M23(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M25(m,d,x,...) m(d,24,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M24(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M26(m,d,x,...) m(d,25,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M25(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M27(m,d,x,...) m(d,26,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M26(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M28(m,d,x,...) m(d,27,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M27(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M29(m,d,x,...) m(d,28,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M28(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M30(m,d,x,...) m(d,29,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M29(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M31(m,d,x,...) m(d,30,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M30(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M32(m,d,x,...) m(d,31,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M31(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M33(m,d,x,...) m(d,32,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M32(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M34(m,d,x,...) m(d,33,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M33(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M35(m,d,x,...) m(d,34,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M34(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M36(m,d,x,...) m(d,35,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M35(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M37(m,d,x,...) m(d,36,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M36(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M38(m,d,x,...) m(d,37,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M37(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M39(m,d,x,...) m(d,38,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M38(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M40(m,d,x,...) m(d,39,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M39(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M41(m,d,x,...) m(d,40,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M40(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M42(m,d,x,...) m(d,41,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M41(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M43(m,d,x,...) m(d,42,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M42(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M44(m,d,x,...) m(d,43,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M43(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M45(m,d,x,...) m(d,44,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M44(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M46(m,d,x,...) m(d,45,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M45(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M47(m,d,x,...) m(d,46,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M46(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M48(m,d,x,...) m(d,47,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M47(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M49(m,d,x,...) m(d,48,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M48(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M50(m,d,x,...) m(d,49,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M49(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M51(m,d,x,...) m(d,50,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M50(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M52(m,d,x,...) m(d,51,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M51(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M53(m,d,x,...) m(d,52,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M52(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M54(m,d,x,...) m(d,53,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M53(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M55(m,d,x,...) m(d,54,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M54(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M56(m,d,x,...) m(d,55,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M55(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M57(m,d,x,...) m(d,56,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M56(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M58(m,d,x,...) m(d,57,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M57(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M59(m,d,x,...) m(d,58,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M58(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M60(m,d,x,...) m(d,59,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M59(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M61(m,d,x,...) m(d,60,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M60(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M62(m,d,x,...) m(d,61,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M61(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M63(m,d,x,...) m(d,62,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M62(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M64(m,d,x,...) m(d,63,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M63(m,d,__VA_ARGS__))
 
-#define BETTER_ENUMS__PP_COUNT_IMPL(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10,   \
+#define BETTER_ENUMS_PP_COUNT_IMPL(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10,   \
     _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, \
     _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, \
     _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, \
     _56, _57, _58, _59, _60, _61, _62, _63, _64, count, ...) count
 
-#define BETTER_ENUMS__PP_COUNT(...) \
-    BETTER_ENUMS__ID(BETTER_ENUMS__PP_COUNT_IMPL(__VA_ARGS__, 64, 63, 62, 61,  \
+#define BETTER_ENUMS_PP_COUNT(...) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_PP_COUNT_IMPL(__VA_ARGS__, 64, 63, 62, 61,  \
         60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43,\
         42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25,\
         24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6,\
         5, 4, 3, 2, 1))
 
-#define BETTER_ENUMS__ITERATE(X, f, l) X(f, l, 0) X(f, l, 1) X(f, l, 2)        \
+#define BETTER_ENUMS_ITERATE(X, f, l) X(f, l, 0) X(f, l, 1) X(f, l, 2)        \
     X(f, l, 3) X(f, l, 4) X(f, l, 5) X(f, l, 6) X(f, l, 7) X(f, l, 8)          \
     X(f, l, 9) X(f, l, 10) X(f, l, 11) X(f, l, 12) X(f, l, 13) X(f, l, 14)     \
     X(f, l, 15) X(f, l, 16) X(f, l, 17) X(f, l, 18) X(f, l, 19) X(f, l, 20)    \
@@ -262,36 +262,36 @@ namespace better_enums {
 // Optional type.
 
 template <typename T>
-BETTER_ENUMS__CONSTEXPR inline T _default()
+BETTER_ENUMS_CONSTEXPR inline T _default()
 {
     return (typename T::_enumerated)0;
 }
 
 template <>
-BETTER_ENUMS__CONSTEXPR inline const char* _default<const char*>()
+BETTER_ENUMS_CONSTEXPR inline const char* _default<const char*>()
 {
-    return BETTER_ENUMS__NULLPTR;
+    return BETTER_ENUMS_NULLPTR;
 }
 
 template <>
-BETTER_ENUMS__CONSTEXPR inline std::size_t _default<std::size_t>()
+BETTER_ENUMS_CONSTEXPR inline std::size_t _default<std::size_t>()
 {
     return 0;
 }
 
 template <typename T>
 struct optional {
-    BETTER_ENUMS__CONSTEXPR optional() :
+    BETTER_ENUMS_CONSTEXPR optional() :
         _valid(false), _value(_default<T>()) { }
 
-    BETTER_ENUMS__CONSTEXPR optional(T v) : _valid(true), _value(v) { }
+    BETTER_ENUMS_CONSTEXPR optional(T v) : _valid(true), _value(v) { }
 
-    BETTER_ENUMS__CONSTEXPR const T& operator *() const { return _value; }
-    BETTER_ENUMS__CONSTEXPR const T* operator ->() const { return &_value; }
+    BETTER_ENUMS_CONSTEXPR const T& operator *() const { return _value; }
+    BETTER_ENUMS_CONSTEXPR const T* operator ->() const { return &_value; }
 
-    BETTER_ENUMS__CONSTEXPR operator bool() const { return _valid; }
+    BETTER_ENUMS_CONSTEXPR operator bool() const { return _valid; }
 
-    BETTER_ENUMS__CONSTEXPR const T& value() const { return _value; }
+    BETTER_ENUMS_CONSTEXPR const T& value() const { return _value; }
 
   private:
     bool    _valid;
@@ -299,15 +299,15 @@ struct optional {
 };
 
 template <typename CastTo, typename Element>
-BETTER_ENUMS__CONSTEXPR static optional<CastTo>
+BETTER_ENUMS_CONSTEXPR static optional<CastTo>
 _map_index(const Element *array, optional<std::size_t> index)
 {
     return index ? (CastTo)array[*index] : optional<CastTo>();
 }
 
-#ifdef BETTER_ENUMS__VC2008_WORKAROUNDS
+#ifdef BETTER_ENUMS_VC2008_WORKAROUNDS
 
-#define BETTER_ENUMS__OR_THROW                                                 \
+#define BETTER_ENUMS_OR_THROW                                                 \
     if (!maybe)                                                                \
         throw std::runtime_error(message);                                     \
                                                                                \
@@ -315,24 +315,24 @@ _map_index(const Element *array, optional<std::size_t> index)
 
 #else
 
-#define BETTER_ENUMS__OR_THROW                                                 \
+#define BETTER_ENUMS_OR_THROW                                                 \
     return maybe ? *maybe : throw std::runtime_error(message);
 
 #endif
 
-BETTER_ENUMS__IF_EXCEPTIONS(
+BETTER_ENUMS_IF_EXCEPTIONS(
 template <typename T>
-BETTER_ENUMS__CONSTEXPR static T _or_throw(optional<T> maybe,
+BETTER_ENUMS_CONSTEXPR static T _or_throw(optional<T> maybe,
                                            const char *message)
 {
-    BETTER_ENUMS__OR_THROW
+    BETTER_ENUMS_OR_THROW
 }
 )
 
 template <typename T>
-BETTER_ENUMS__CONSTEXPR static T* _or_null(optional<T*> maybe)
+BETTER_ENUMS_CONSTEXPR static T* _or_null(optional<T*> maybe)
 {
-    return maybe ? *maybe : BETTER_ENUMS__NULLPTR;
+    return maybe ? *maybe : BETTER_ENUMS_NULLPTR;
 }
 
 
@@ -343,8 +343,8 @@ BETTER_ENUMS__CONSTEXPR static T* _or_null(optional<T*> maybe)
 // causes a linking error.
 
 template <typename T, typename U>
-BETTER_ENUMS__CONSTEXPR U
-continue_with(T BETTER_ENUMS__UNUSED(ignored), U value) { return value; }
+BETTER_ENUMS_CONSTEXPR U
+continue_with(T BETTER_ENUMS_UNUSED(ignored), U value) { return value; }
 
 
 
@@ -352,14 +352,14 @@ continue_with(T BETTER_ENUMS__UNUSED(ignored), U value) { return value; }
 
 template <typename EnumType>
 struct _eat_assign {
-    explicit BETTER_ENUMS__CONSTEXPR _eat_assign(EnumType value) : _value(value)
+    explicit BETTER_ENUMS_CONSTEXPR _eat_assign(EnumType value) : _value(value)
         { }
 
     template <typename Any>
-    BETTER_ENUMS__CONSTEXPR const _eat_assign&
-    operator =(Any BETTER_ENUMS__UNUSED(dummy)) const { return *this; }
+    BETTER_ENUMS_CONSTEXPR const _eat_assign&
+    operator =(Any BETTER_ENUMS_UNUSED(dummy)) const { return *this; }
 
-    BETTER_ENUMS__CONSTEXPR operator EnumType () const { return _value; }
+    BETTER_ENUMS_CONSTEXPR operator EnumType () const { return _value; }
 
   private:
     EnumType    _value;
@@ -373,14 +373,14 @@ template <typename Element>
 struct _Iterable {
     typedef const Element*  iterator;
 
-    BETTER_ENUMS__CONSTEXPR iterator begin() const { return iterator(_array); }
-    BETTER_ENUMS__CONSTEXPR iterator end() const
+    BETTER_ENUMS_CONSTEXPR iterator begin() const { return iterator(_array); }
+    BETTER_ENUMS_CONSTEXPR iterator end() const
         { return iterator(_array + _size); }
-    BETTER_ENUMS__CONSTEXPR std::size_t size() const { return _size; }
-    BETTER_ENUMS__CONSTEXPR const Element& operator [](std::size_t index) const
+    BETTER_ENUMS_CONSTEXPR std::size_t size() const { return _size; }
+    BETTER_ENUMS_CONSTEXPR const Element& operator [](std::size_t index) const
         { return _array[index]; }
 
-    BETTER_ENUMS__CONSTEXPR _Iterable(const Element *array, std::size_t s) :
+    BETTER_ENUMS_CONSTEXPR _Iterable(const Element *array, std::size_t s) :
         _array(array), _size(s) { }
 
   private:
@@ -392,9 +392,9 @@ struct _Iterable {
 
 // String routines.
 
-BETTER_ENUMS__CONSTEXPR static const char       *_name_enders = "= \t\n";
+BETTER_ENUMS_CONSTEXPR static const char       *_name_enders = "= \t\n";
 
-BETTER_ENUMS__CONSTEXPR inline bool _ends_name(char c, std::size_t index = 0)
+BETTER_ENUMS_CONSTEXPR inline bool _ends_name(char c, std::size_t index = 0)
 {
     return
         c == _name_enders[index] ? true  :
@@ -402,7 +402,7 @@ BETTER_ENUMS__CONSTEXPR inline bool _ends_name(char c, std::size_t index = 0)
         _ends_name(c, index + 1);
 }
 
-BETTER_ENUMS__CONSTEXPR inline bool _has_initializer(const char *s,
+BETTER_ENUMS_CONSTEXPR inline bool _has_initializer(const char *s,
                                                      std::size_t index = 0)
 {
     return
@@ -411,24 +411,24 @@ BETTER_ENUMS__CONSTEXPR inline bool _has_initializer(const char *s,
         _has_initializer(s, index + 1);
 }
 
-BETTER_ENUMS__CONSTEXPR inline std::size_t
+BETTER_ENUMS_CONSTEXPR inline std::size_t
 _constant_length(const char *s, std::size_t index = 0)
 {
     return _ends_name(s[index]) ? index : _constant_length(s, index + 1);
 }
 
-BETTER_ENUMS__CONSTEXPR inline char
+BETTER_ENUMS_CONSTEXPR inline char
 _select(const char *from, std::size_t from_length, std::size_t index)
 {
     return index >= from_length ? '\0' : from[index];
 }
 
-BETTER_ENUMS__CONSTEXPR inline char _to_lower_ascii(char c)
+BETTER_ENUMS_CONSTEXPR inline char _to_lower_ascii(char c)
 {
     return c >= 0x41 && c <= 0x5A ? (char)(c + 0x20) : c;
 }
 
-BETTER_ENUMS__CONSTEXPR inline bool _names_match(const char *stringizedName,
+BETTER_ENUMS_CONSTEXPR inline bool _names_match(const char *stringizedName,
                                                  const char *referenceName,
                                                  std::size_t index = 0)
 {
@@ -439,7 +439,7 @@ BETTER_ENUMS__CONSTEXPR inline bool _names_match(const char *stringizedName,
         _names_match(stringizedName, referenceName, index + 1);
 }
 
-BETTER_ENUMS__CONSTEXPR inline bool
+BETTER_ENUMS_CONSTEXPR inline bool
 _names_match_nocase(const char *stringizedName, const char *referenceName,
                     std::size_t index = 0)
 {
@@ -483,93 +483,93 @@ struct _initialize_at_program_start {
 
 // Array generation macros.
 
-#define BETTER_ENUMS__EAT_ASSIGN_SINGLE(EnumType, index, expression)           \
+#define BETTER_ENUMS_EAT_ASSIGN_SINGLE(EnumType, index, expression)           \
     ((::better_enums::_eat_assign<EnumType>)EnumType::expression),
 
-#define BETTER_ENUMS__EAT_ASSIGN(EnumType, ...)                                \
-    BETTER_ENUMS__ID(                                                          \
-        BETTER_ENUMS__PP_MAP(                                                  \
-            BETTER_ENUMS__EAT_ASSIGN_SINGLE, EnumType, __VA_ARGS__))
+#define BETTER_ENUMS_EAT_ASSIGN(EnumType, ...)                                \
+    BETTER_ENUMS_ID(                                                          \
+        BETTER_ENUMS_PP_MAP(                                                  \
+            BETTER_ENUMS_EAT_ASSIGN_SINGLE, EnumType, __VA_ARGS__))
 
 
 
-#ifdef BETTER_ENUMS__HAVE_CONSTEXPR
+#ifdef BETTER_ENUMS_HAVE_CONSTEXPR
 
 
 
-#define BETTER_ENUMS__SELECT_SINGLE_CHARACTER(from, from_length, index)        \
+#define BETTER_ENUMS_SELECT_SINGLE_CHARACTER(from, from_length, index)        \
     ::better_enums::_select(from, from_length, index),
 
-#define BETTER_ENUMS__SELECT_CHARACTERS(from, from_length)                     \
-    BETTER_ENUMS__ITERATE(                                                     \
-        BETTER_ENUMS__SELECT_SINGLE_CHARACTER, from, from_length)
+#define BETTER_ENUMS_SELECT_CHARACTERS(from, from_length)                     \
+    BETTER_ENUMS_ITERATE(                                                     \
+        BETTER_ENUMS_SELECT_SINGLE_CHARACTER, from, from_length)
 
 
 
-#define BETTER_ENUMS__TRIM_SINGLE_STRING(ignored, index, expression)           \
+#define BETTER_ENUMS_TRIM_SINGLE_STRING(ignored, index, expression)           \
 constexpr std::size_t   _length_ ## index =                                    \
     ::better_enums::_constant_length(#expression);                             \
 constexpr const char    _trimmed_ ## index [] =                                \
-    { BETTER_ENUMS__SELECT_CHARACTERS(#expression, _length_ ## index) };       \
+    { BETTER_ENUMS_SELECT_CHARACTERS(#expression, _length_ ## index) };       \
 constexpr const char    *_final_ ## index =                                    \
     ::better_enums::_has_initializer(#expression) ?                            \
         _trimmed_ ## index : #expression;
 
-#define BETTER_ENUMS__TRIM_STRINGS(...)                                        \
-    BETTER_ENUMS__ID(                                                          \
-        BETTER_ENUMS__PP_MAP(                                                  \
-            BETTER_ENUMS__TRIM_SINGLE_STRING, ignored, __VA_ARGS__))
+#define BETTER_ENUMS_TRIM_STRINGS(...)                                        \
+    BETTER_ENUMS_ID(                                                          \
+        BETTER_ENUMS_PP_MAP(                                                  \
+            BETTER_ENUMS_TRIM_SINGLE_STRING, ignored, __VA_ARGS__))
 
 
 
-#define BETTER_ENUMS__REFER_TO_SINGLE_STRING(ignored, index, expression)       \
+#define BETTER_ENUMS_REFER_TO_SINGLE_STRING(ignored, index, expression)       \
     _final_ ## index,
 
-#define BETTER_ENUMS__REFER_TO_STRINGS(...)                                    \
-    BETTER_ENUMS__ID(                                                          \
-        BETTER_ENUMS__PP_MAP(                                                  \
-            BETTER_ENUMS__REFER_TO_SINGLE_STRING, ignored, __VA_ARGS__))
+#define BETTER_ENUMS_REFER_TO_STRINGS(...)                                    \
+    BETTER_ENUMS_ID(                                                          \
+        BETTER_ENUMS_PP_MAP(                                                  \
+            BETTER_ENUMS_REFER_TO_SINGLE_STRING, ignored, __VA_ARGS__))
 
 
 
-#endif // #ifdef BETTER_ENUMS__HAVE_CONSTEXPR
+#endif // #ifdef BETTER_ENUMS_HAVE_CONSTEXPR
 
 
 
-#define BETTER_ENUMS__STRINGIZE_SINGLE(ignored, index, expression)  #expression,
+#define BETTER_ENUMS_STRINGIZE_SINGLE(ignored, index, expression)  #expression,
 
-#define BETTER_ENUMS__STRINGIZE(...)                                           \
-    BETTER_ENUMS__ID(                                                          \
-        BETTER_ENUMS__PP_MAP(                                                  \
-            BETTER_ENUMS__STRINGIZE_SINGLE, ignored, __VA_ARGS__))
+#define BETTER_ENUMS_STRINGIZE(...)                                           \
+    BETTER_ENUMS_ID(                                                          \
+        BETTER_ENUMS_PP_MAP(                                                  \
+            BETTER_ENUMS_STRINGIZE_SINGLE, ignored, __VA_ARGS__))
 
-#define BETTER_ENUMS__RESERVE_STORAGE_SINGLE(ignored, index, expression)       \
+#define BETTER_ENUMS_RESERVE_STORAGE_SINGLE(ignored, index, expression)       \
     #expression ","
 
-#define BETTER_ENUMS__RESERVE_STORAGE(...)                                     \
-    BETTER_ENUMS__ID(                                                          \
-        BETTER_ENUMS__PP_MAP(                                                  \
-            BETTER_ENUMS__RESERVE_STORAGE_SINGLE, ignored, __VA_ARGS__))
+#define BETTER_ENUMS_RESERVE_STORAGE(...)                                     \
+    BETTER_ENUMS_ID(                                                          \
+        BETTER_ENUMS_PP_MAP(                                                  \
+            BETTER_ENUMS_RESERVE_STORAGE_SINGLE, ignored, __VA_ARGS__))
 
 
 
 // The enums proper.
 
-#define BETTER_ENUMS__NS(EnumType)  better_enums::_data_ ## EnumType
+#define BETTER_ENUMS_NS(EnumType)  better_enums::_data_ ## EnumType
 
-#ifdef BETTER_ENUMS__VC2008_WORKAROUNDS
+#ifdef BETTER_ENUMS_VC2008_WORKAROUNDS
 
-#define BETTER_ENUMS__COPY_CONSTRUCTOR(Enum)                                   \
-        BETTER_ENUMS__CONSTEXPR Enum(const Enum &other) :                      \
+#define BETTER_ENUMS_COPY_CONSTRUCTOR(Enum)                                   \
+        BETTER_ENUMS_CONSTEXPR Enum(const Enum &other) :                      \
             _value(other._value) { }
 
 #else
 
-#define BETTER_ENUMS__COPY_CONSTRUCTOR(Enum)
+#define BETTER_ENUMS_COPY_CONSTRUCTOR(Enum)
 
 #endif
 
-#define BETTER_ENUMS__TYPE(SetUnderlyingType, SwitchType, GenerateSwitchType,  \
+#define BETTER_ENUMS_TYPE(SetUnderlyingType, SwitchType, GenerateSwitchType,  \
                            GenerateStrings, ToStringConstexpr,                 \
                            DeclareInitialize, DefineInitialize, CallInitialize,\
                            Enum, Underlying, ...)                              \
@@ -577,7 +577,7 @@ constexpr const char    *_final_ ## index =                                    \
 namespace better_enums {                                                       \
 namespace _data_ ## Enum {                                                     \
                                                                                \
-BETTER_ENUMS__ID(GenerateSwitchType(Underlying, __VA_ARGS__))                  \
+BETTER_ENUMS_ID(GenerateSwitchType(Underlying, __VA_ARGS__))                  \
                                                                                \
 }                                                                              \
 }                                                                              \
@@ -592,40 +592,40 @@ class Enum {                                                                   \
                                                                                \
     enum _enumerated SetUnderlyingType(Underlying) { __VA_ARGS__ };            \
                                                                                \
-    BETTER_ENUMS__CONSTEXPR Enum(_enumerated value) : _value(value) { }        \
+    BETTER_ENUMS_CONSTEXPR Enum(_enumerated value) : _value(value) { }        \
                                                                                \
-    BETTER_ENUMS__COPY_CONSTRUCTOR(Enum)                                       \
+    BETTER_ENUMS_COPY_CONSTRUCTOR(Enum)                                       \
                                                                                \
-    BETTER_ENUMS__CONSTEXPR operator SwitchType(Enum)() const                  \
+    BETTER_ENUMS_CONSTEXPR operator SwitchType(Enum)() const                  \
     {                                                                          \
         return SwitchType(Enum)(_value);                                       \
     }                                                                          \
                                                                                \
-    BETTER_ENUMS__CONSTEXPR _integral _to_integral() const;                    \
-    BETTER_ENUMS__IF_EXCEPTIONS(                                               \
-    BETTER_ENUMS__CONSTEXPR static Enum _from_integral(_integral value);       \
+    BETTER_ENUMS_CONSTEXPR _integral _to_integral() const;                    \
+    BETTER_ENUMS_IF_EXCEPTIONS(                                               \
+    BETTER_ENUMS_CONSTEXPR static Enum _from_integral(_integral value);       \
     )                                                                          \
-    BETTER_ENUMS__CONSTEXPR static Enum                                        \
+    BETTER_ENUMS_CONSTEXPR static Enum                                        \
     _from_integral_unchecked(_integral value);                                 \
-    BETTER_ENUMS__CONSTEXPR static _optional                                   \
+    BETTER_ENUMS_CONSTEXPR static _optional                                   \
     _from_integral_nothrow(_integral value);                                   \
                                                                                \
     ToStringConstexpr const char* _to_string() const;                          \
-    BETTER_ENUMS__IF_EXCEPTIONS(                                               \
-    BETTER_ENUMS__CONSTEXPR static Enum _from_string(const char *name);        \
+    BETTER_ENUMS_IF_EXCEPTIONS(                                               \
+    BETTER_ENUMS_CONSTEXPR static Enum _from_string(const char *name);        \
     )                                                                          \
-    BETTER_ENUMS__CONSTEXPR static _optional                                   \
+    BETTER_ENUMS_CONSTEXPR static _optional                                   \
     _from_string_nothrow(const char *name);                                    \
                                                                                \
-    BETTER_ENUMS__IF_EXCEPTIONS(                                               \
-    BETTER_ENUMS__CONSTEXPR static Enum _from_string_nocase(const char *name); \
+    BETTER_ENUMS_IF_EXCEPTIONS(                                               \
+    BETTER_ENUMS_CONSTEXPR static Enum _from_string_nocase(const char *name); \
     )                                                                          \
-    BETTER_ENUMS__CONSTEXPR static _optional                                   \
+    BETTER_ENUMS_CONSTEXPR static _optional                                   \
     _from_string_nocase_nothrow(const char *name);                             \
                                                                                \
-    BETTER_ENUMS__CONSTEXPR static bool _is_valid(_integral value);            \
-    BETTER_ENUMS__CONSTEXPR static bool _is_valid(const char *name);           \
-    BETTER_ENUMS__CONSTEXPR static bool _is_valid_nocase(const char *name);    \
+    BETTER_ENUMS_CONSTEXPR static bool _is_valid(_integral value);            \
+    BETTER_ENUMS_CONSTEXPR static bool _is_valid(const char *name);           \
+    BETTER_ENUMS_CONSTEXPR static bool _is_valid_nocase(const char *name);    \
                                                                                \
     typedef ::better_enums::_Iterable<Enum>             _value_iterable;       \
     typedef ::better_enums::_Iterable<const char*>      _name_iterable;        \
@@ -633,13 +633,13 @@ class Enum {                                                                   \
     typedef _value_iterable::iterator                   _value_iterator;       \
     typedef _name_iterable::iterator                    _name_iterator;        \
                                                                                \
-    BETTER_ENUMS__CONSTEXPR static const std::size_t _size_constant =          \
-        BETTER_ENUMS__ID(BETTER_ENUMS__PP_COUNT(__VA_ARGS__));                 \
-    BETTER_ENUMS__CONSTEXPR static std::size_t _size()                         \
+    BETTER_ENUMS_CONSTEXPR static const std::size_t _size_constant =          \
+        BETTER_ENUMS_ID(BETTER_ENUMS_PP_COUNT(__VA_ARGS__));                 \
+    BETTER_ENUMS_CONSTEXPR static std::size_t _size()                         \
         { return _size_constant; }                                             \
                                                                                \
-    BETTER_ENUMS__CONSTEXPR static const char* _name();                        \
-    BETTER_ENUMS__CONSTEXPR static _value_iterable _values();                  \
+    BETTER_ENUMS_CONSTEXPR static const char* _name();                        \
+    BETTER_ENUMS_CONSTEXPR static _value_iterable _values();                  \
     ToStringConstexpr static _name_iterable _names();                          \
                                                                                \
     _integral      _value;                                                     \
@@ -647,16 +647,16 @@ class Enum {                                                                   \
     BETTER_ENUMS_DEFAULT_CONSTRUCTOR(Enum)                                     \
                                                                                \
   private:                                                                     \
-    explicit BETTER_ENUMS__CONSTEXPR Enum(const _integral &value) :            \
+    explicit BETTER_ENUMS_CONSTEXPR Enum(const _integral &value) :            \
         _value(value) { }                                                      \
                                                                                \
     DeclareInitialize                                                          \
                                                                                \
-    BETTER_ENUMS__CONSTEXPR static _optional_index                             \
+    BETTER_ENUMS_CONSTEXPR static _optional_index                             \
     _from_value_loop(_integral value, std::size_t index = 0);                  \
-    BETTER_ENUMS__CONSTEXPR static _optional_index                             \
+    BETTER_ENUMS_CONSTEXPR static _optional_index                             \
     _from_string_loop(const char *name, std::size_t index = 0);                \
-    BETTER_ENUMS__CONSTEXPR static _optional_index                             \
+    BETTER_ENUMS_CONSTEXPR static _optional_index                             \
     _from_string_nocase_loop(const char *name, std::size_t index = 0);         \
                                                                                \
     friend struct ::better_enums::_initialize_at_program_start<Enum>;          \
@@ -670,74 +670,74 @@ static ::better_enums::_initialize_at_program_start<Enum>                      \
                                                                                \
 enum _PutNamesInThisScopeAlso { __VA_ARGS__ };                                 \
                                                                                \
-BETTER_ENUMS__CONSTEXPR const Enum      _value_array[] =                       \
-    { BETTER_ENUMS__ID(BETTER_ENUMS__EAT_ASSIGN(Enum, __VA_ARGS__)) };         \
+BETTER_ENUMS_CONSTEXPR const Enum      _value_array[] =                       \
+    { BETTER_ENUMS_ID(BETTER_ENUMS_EAT_ASSIGN(Enum, __VA_ARGS__)) };         \
                                                                                \
-BETTER_ENUMS__ID(GenerateStrings(Enum, __VA_ARGS__))                           \
+BETTER_ENUMS_ID(GenerateStrings(Enum, __VA_ARGS__))                           \
                                                                                \
 }                                                                              \
 }                                                                              \
                                                                                \
-BETTER_ENUMS__CONSTEXPR inline const Enum                                      \
+BETTER_ENUMS_CONSTEXPR inline const Enum                                      \
 operator +(Enum::_enumerated enumerated)                                       \
 {                                                                              \
     return (Enum)enumerated;                                                   \
 }                                                                              \
                                                                                \
-BETTER_ENUMS__CONSTEXPR inline Enum::_optional_index                           \
+BETTER_ENUMS_CONSTEXPR inline Enum::_optional_index                           \
 Enum::_from_value_loop(Enum::_integral value, std::size_t index)               \
 {                                                                              \
     return                                                                     \
         index == _size() ?                                                     \
             _optional_index() :                                                \
-            BETTER_ENUMS__NS(Enum)::_value_array[index]._value == value ?      \
+            BETTER_ENUMS_NS(Enum)::_value_array[index]._value == value ?      \
                 _optional_index(index) :                                       \
                 _from_value_loop(value, index + 1);                            \
 }                                                                              \
                                                                                \
-BETTER_ENUMS__CONSTEXPR inline Enum::_optional_index                           \
+BETTER_ENUMS_CONSTEXPR inline Enum::_optional_index                           \
 Enum::_from_string_loop(const char *name, std::size_t index)                   \
 {                                                                              \
     return                                                                     \
         index == _size() ? _optional_index() :                                 \
         ::better_enums::_names_match(                                          \
-            BETTER_ENUMS__NS(Enum)::_raw_names()[index], name) ?               \
+            BETTER_ENUMS_NS(Enum)::_raw_names()[index], name) ?               \
             _optional_index(index) :                                           \
             _from_string_loop(name, index + 1);                                \
 }                                                                              \
                                                                                \
-BETTER_ENUMS__CONSTEXPR inline Enum::_optional_index                           \
+BETTER_ENUMS_CONSTEXPR inline Enum::_optional_index                           \
 Enum::_from_string_nocase_loop(const char *name, std::size_t index)            \
 {                                                                              \
     return                                                                     \
         index == _size() ? _optional_index() :                                 \
             ::better_enums::_names_match_nocase(                               \
-                BETTER_ENUMS__NS(Enum)::_raw_names()[index], name) ?           \
+                BETTER_ENUMS_NS(Enum)::_raw_names()[index], name) ?           \
                     _optional_index(index) :                                   \
                     _from_string_nocase_loop(name, index + 1);                 \
 }                                                                              \
                                                                                \
-BETTER_ENUMS__CONSTEXPR inline Enum::_integral Enum::_to_integral() const      \
+BETTER_ENUMS_CONSTEXPR inline Enum::_integral Enum::_to_integral() const      \
 {                                                                              \
     return _integral(_value);                                                  \
 }                                                                              \
                                                                                \
-BETTER_ENUMS__CONSTEXPR inline Enum                                            \
+BETTER_ENUMS_CONSTEXPR inline Enum                                            \
 Enum::_from_integral_unchecked(_integral value)                                \
 {                                                                              \
     return (_enumerated)value;                                                 \
 }                                                                              \
                                                                                \
-BETTER_ENUMS__CONSTEXPR inline Enum::_optional                                 \
+BETTER_ENUMS_CONSTEXPR inline Enum::_optional                                 \
 Enum::_from_integral_nothrow(_integral value)                                  \
 {                                                                              \
     return                                                                     \
-        ::better_enums::_map_index<Enum>(BETTER_ENUMS__NS(Enum)::_value_array, \
+        ::better_enums::_map_index<Enum>(BETTER_ENUMS_NS(Enum)::_value_array, \
                                          _from_value_loop(value));             \
 }                                                                              \
                                                                                \
-BETTER_ENUMS__IF_EXCEPTIONS(                                                   \
-BETTER_ENUMS__CONSTEXPR inline Enum Enum::_from_integral(_integral value)      \
+BETTER_ENUMS_IF_EXCEPTIONS(                                                   \
+BETTER_ENUMS_CONSTEXPR inline Enum Enum::_from_integral(_integral value)      \
 {                                                                              \
     return                                                                     \
         ::better_enums::_or_throw(_from_integral_nothrow(value),               \
@@ -750,20 +750,20 @@ ToStringConstexpr inline const char* Enum::_to_string() const                  \
     return                                                                     \
         ::better_enums::_or_null(                                              \
             ::better_enums::_map_index<const char*>(                           \
-                BETTER_ENUMS__NS(Enum)::_name_array(),                         \
+                BETTER_ENUMS_NS(Enum)::_name_array(),                         \
                 _from_value_loop(CallInitialize(_value))));                    \
 }                                                                              \
                                                                                \
-BETTER_ENUMS__CONSTEXPR inline Enum::_optional                                 \
+BETTER_ENUMS_CONSTEXPR inline Enum::_optional                                 \
 Enum::_from_string_nothrow(const char *name)                                   \
 {                                                                              \
     return                                                                     \
         ::better_enums::_map_index<Enum>(                                      \
-            BETTER_ENUMS__NS(Enum)::_value_array, _from_string_loop(name));    \
+            BETTER_ENUMS_NS(Enum)::_value_array, _from_string_loop(name));    \
 }                                                                              \
                                                                                \
-BETTER_ENUMS__IF_EXCEPTIONS(                                                   \
-BETTER_ENUMS__CONSTEXPR inline Enum Enum::_from_string(const char *name)       \
+BETTER_ENUMS_IF_EXCEPTIONS(                                                   \
+BETTER_ENUMS_CONSTEXPR inline Enum Enum::_from_string(const char *name)       \
 {                                                                              \
     return                                                                     \
         ::better_enums::_or_throw(_from_string_nothrow(name),                  \
@@ -771,16 +771,16 @@ BETTER_ENUMS__CONSTEXPR inline Enum Enum::_from_string(const char *name)       \
 }                                                                              \
 )                                                                              \
                                                                                \
-BETTER_ENUMS__CONSTEXPR inline Enum::_optional                                 \
+BETTER_ENUMS_CONSTEXPR inline Enum::_optional                                 \
 Enum::_from_string_nocase_nothrow(const char *name)                            \
 {                                                                              \
     return                                                                     \
-        ::better_enums::_map_index<Enum>(BETTER_ENUMS__NS(Enum)::_value_array, \
+        ::better_enums::_map_index<Enum>(BETTER_ENUMS_NS(Enum)::_value_array, \
                                          _from_string_nocase_loop(name));      \
 }                                                                              \
                                                                                \
-BETTER_ENUMS__IF_EXCEPTIONS(                                                   \
-BETTER_ENUMS__CONSTEXPR inline Enum Enum::_from_string_nocase(const char *name)\
+BETTER_ENUMS_IF_EXCEPTIONS(                                                   \
+BETTER_ENUMS_CONSTEXPR inline Enum Enum::_from_string_nocase(const char *name)\
 {                                                                              \
     return                                                                     \
         ::better_enums::_or_throw(                                             \
@@ -789,51 +789,51 @@ BETTER_ENUMS__CONSTEXPR inline Enum Enum::_from_string_nocase(const char *name)\
 }                                                                              \
 )                                                                              \
                                                                                \
-BETTER_ENUMS__CONSTEXPR inline bool Enum::_is_valid(_integral value)           \
+BETTER_ENUMS_CONSTEXPR inline bool Enum::_is_valid(_integral value)           \
 {                                                                              \
     return _from_value_loop(value);                                            \
 }                                                                              \
                                                                                \
-BETTER_ENUMS__CONSTEXPR inline bool Enum::_is_valid(const char *name)          \
+BETTER_ENUMS_CONSTEXPR inline bool Enum::_is_valid(const char *name)          \
 {                                                                              \
     return _from_string_loop(name);                                            \
 }                                                                              \
                                                                                \
-BETTER_ENUMS__CONSTEXPR inline bool Enum::_is_valid_nocase(const char *name)   \
+BETTER_ENUMS_CONSTEXPR inline bool Enum::_is_valid_nocase(const char *name)   \
 {                                                                              \
     return _from_string_nocase_loop(name);                                     \
 }                                                                              \
                                                                                \
-BETTER_ENUMS__CONSTEXPR inline const char* Enum::_name()                       \
+BETTER_ENUMS_CONSTEXPR inline const char* Enum::_name()                       \
 {                                                                              \
     return #Enum;                                                              \
 }                                                                              \
                                                                                \
-BETTER_ENUMS__CONSTEXPR inline Enum::_value_iterable Enum::_values()           \
+BETTER_ENUMS_CONSTEXPR inline Enum::_value_iterable Enum::_values()           \
 {                                                                              \
-    return _value_iterable(BETTER_ENUMS__NS(Enum)::_value_array, _size());     \
+    return _value_iterable(BETTER_ENUMS_NS(Enum)::_value_array, _size());     \
 }                                                                              \
                                                                                \
 ToStringConstexpr inline Enum::_name_iterable Enum::_names()                   \
 {                                                                              \
     return                                                                     \
-        _name_iterable(BETTER_ENUMS__NS(Enum)::_name_array(),                  \
+        _name_iterable(BETTER_ENUMS_NS(Enum)::_name_array(),                  \
                        CallInitialize(_size()));                               \
 }                                                                              \
                                                                                \
 DefineInitialize(Enum)                                                         \
                                                                                \
-BETTER_ENUMS__CONSTEXPR inline bool operator ==(const Enum &a, const Enum &b)  \
+BETTER_ENUMS_CONSTEXPR inline bool operator ==(const Enum &a, const Enum &b)  \
     { return a._to_integral() == b._to_integral(); }                           \
-BETTER_ENUMS__CONSTEXPR inline bool operator !=(const Enum &a, const Enum &b)  \
+BETTER_ENUMS_CONSTEXPR inline bool operator !=(const Enum &a, const Enum &b)  \
     { return a._to_integral() != b._to_integral(); }                           \
-BETTER_ENUMS__CONSTEXPR inline bool operator <(const Enum &a, const Enum &b)   \
+BETTER_ENUMS_CONSTEXPR inline bool operator <(const Enum &a, const Enum &b)   \
     { return a._to_integral() < b._to_integral(); }                            \
-BETTER_ENUMS__CONSTEXPR inline bool operator <=(const Enum &a, const Enum &b)  \
+BETTER_ENUMS_CONSTEXPR inline bool operator <=(const Enum &a, const Enum &b)  \
     { return a._to_integral() <= b._to_integral(); }                           \
-BETTER_ENUMS__CONSTEXPR inline bool operator >(const Enum &a, const Enum &b)   \
+BETTER_ENUMS_CONSTEXPR inline bool operator >(const Enum &a, const Enum &b)   \
     { return a._to_integral() > b._to_integral(); }                            \
-BETTER_ENUMS__CONSTEXPR inline bool operator >=(const Enum &a, const Enum &b)  \
+BETTER_ENUMS_CONSTEXPR inline bool operator >=(const Enum &a, const Enum &b)  \
     { return a._to_integral() >= b._to_integral(); }
 
 
@@ -841,40 +841,40 @@ BETTER_ENUMS__CONSTEXPR inline bool operator >=(const Enum &a, const Enum &b)  \
 // Enum feature options.
 
 // C++98, C++11
-#define BETTER_ENUMS__CXX98_UNDERLYING_TYPE(Underlying)
+#define BETTER_ENUMS_CXX98_UNDERLYING_TYPE(Underlying)
 
 // C++11
-#define BETTER_ENUMS__CXX11_UNDERLYING_TYPE(Underlying)                        \
+#define BETTER_ENUMS_CXX11_UNDERLYING_TYPE(Underlying)                        \
     : Underlying
 
 // C++98, C++11
-#define BETTER_ENUMS__REGULAR_ENUM_SWITCH_TYPE(Type)                           \
+#define BETTER_ENUMS_REGULAR_ENUM_SWITCH_TYPE(Type)                           \
     _enumerated
 
 // C++11
-#define BETTER_ENUMS__ENUM_CLASS_SWITCH_TYPE(Type)                             \
-    BETTER_ENUMS__NS(Type)::_EnumClassForSwitchStatements
+#define BETTER_ENUMS_ENUM_CLASS_SWITCH_TYPE(Type)                             \
+    BETTER_ENUMS_NS(Type)::_EnumClassForSwitchStatements
 
 // C++98, C++11
-#define BETTER_ENUMS__REGULAR_ENUM_SWITCH_TYPE_GENERATE(Underlying, ...)
+#define BETTER_ENUMS_REGULAR_ENUM_SWITCH_TYPE_GENERATE(Underlying, ...)
 
 // C++11
-#define BETTER_ENUMS__ENUM_CLASS_SWITCH_TYPE_GENERATE(Underlying, ...)         \
+#define BETTER_ENUMS_ENUM_CLASS_SWITCH_TYPE_GENERATE(Underlying, ...)         \
     enum class _EnumClassForSwitchStatements : Underlying { __VA_ARGS__ };
 
 // C++98
-#define BETTER_ENUMS__CXX98_TRIM_STRINGS_ARRAYS(Enum, ...)                     \
+#define BETTER_ENUMS_CXX98_TRIM_STRINGS_ARRAYS(Enum, ...)                     \
     inline const char** _raw_names()                                           \
     {                                                                          \
         static const char   *value[] =                                         \
-            { BETTER_ENUMS__ID(BETTER_ENUMS__STRINGIZE(__VA_ARGS__)) };        \
+            { BETTER_ENUMS_ID(BETTER_ENUMS_STRINGIZE(__VA_ARGS__)) };        \
         return value;                                                          \
     }                                                                          \
                                                                                \
     inline char* _name_storage()                                               \
     {                                                                          \
         static char         storage[] =                                        \
-            BETTER_ENUMS__ID(BETTER_ENUMS__RESERVE_STORAGE(__VA_ARGS__));      \
+            BETTER_ENUMS_ID(BETTER_ENUMS_RESERVE_STORAGE(__VA_ARGS__));      \
         return storage;                                                        \
     }                                                                          \
                                                                                \
@@ -891,9 +891,9 @@ BETTER_ENUMS__CONSTEXPR inline bool operator >=(const Enum &a, const Enum &b)  \
     }
 
 // C++11 fast version
-#define BETTER_ENUMS__CXX11_PARTIAL_CONSTEXPR_TRIM_STRINGS_ARRAYS(Enum, ...)   \
+#define BETTER_ENUMS_CXX11_PARTIAL_CONSTEXPR_TRIM_STRINGS_ARRAYS(Enum, ...)   \
     constexpr const char    *_the_raw_names[] =                                \
-        { BETTER_ENUMS__ID(BETTER_ENUMS__STRINGIZE(__VA_ARGS__)) };            \
+        { BETTER_ENUMS_ID(BETTER_ENUMS_STRINGIZE(__VA_ARGS__)) };            \
                                                                                \
     constexpr const char * const * _raw_names()                                \
     {                                                                          \
@@ -903,7 +903,7 @@ BETTER_ENUMS__CONSTEXPR inline bool operator >=(const Enum &a, const Enum &b)  \
     inline char* _name_storage()                                               \
     {                                                                          \
         static char         storage[] =                                        \
-            BETTER_ENUMS__ID(BETTER_ENUMS__RESERVE_STORAGE(__VA_ARGS__));      \
+            BETTER_ENUMS_ID(BETTER_ENUMS_RESERVE_STORAGE(__VA_ARGS__));      \
         return storage;                                                        \
     }                                                                          \
                                                                                \
@@ -920,11 +920,11 @@ BETTER_ENUMS__CONSTEXPR inline bool operator >=(const Enum &a, const Enum &b)  \
     }
 
 // C++11 slow all-constexpr version
-#define BETTER_ENUMS__CXX11_FULL_CONSTEXPR_TRIM_STRINGS_ARRAYS(Enum, ...)      \
-    BETTER_ENUMS__ID(BETTER_ENUMS__TRIM_STRINGS(__VA_ARGS__))                  \
+#define BETTER_ENUMS_CXX11_FULL_CONSTEXPR_TRIM_STRINGS_ARRAYS(Enum, ...)      \
+    BETTER_ENUMS_ID(BETTER_ENUMS_TRIM_STRINGS(__VA_ARGS__))                  \
                                                                                \
     constexpr const char * const    _the_name_array[] =                        \
-        { BETTER_ENUMS__ID(BETTER_ENUMS__REFER_TO_STRINGS(__VA_ARGS__)) };     \
+        { BETTER_ENUMS_ID(BETTER_ENUMS_REFER_TO_STRINGS(__VA_ARGS__)) };     \
                                                                                \
     constexpr const char * const * _name_array()                               \
     {                                                                          \
@@ -937,46 +937,46 @@ BETTER_ENUMS__CONSTEXPR inline bool operator >=(const Enum &a, const Enum &b)  \
     }
 
 // C++98, C++11 fast version
-#define BETTER_ENUMS__NO_CONSTEXPR_TO_STRING_KEYWORD
+#define BETTER_ENUMS_NO_CONSTEXPR_TO_STRING_KEYWORD
 
 // C++11 slow all-constexpr version
-#define BETTER_ENUMS__CONSTEXPR_TO_STRING_KEYWORD                              \
+#define BETTER_ENUMS_CONSTEXPR_TO_STRING_KEYWORD                              \
     constexpr
 
 // C++98, C++11 fast version
-#define BETTER_ENUMS__DO_DECLARE_INITIALIZE                                    \
+#define BETTER_ENUMS_DO_DECLARE_INITIALIZE                                    \
     static int initialize();
 
 // C++11 slow all-constexpr version
-#define BETTER_ENUMS__DECLARE_EMPTY_INITIALIZE                                 \
+#define BETTER_ENUMS_DECLARE_EMPTY_INITIALIZE                                 \
     static int initialize() { return 0; }
 
 // C++98, C++11 fast version
-#define BETTER_ENUMS__DO_DEFINE_INITIALIZE(Enum)                               \
+#define BETTER_ENUMS_DO_DEFINE_INITIALIZE(Enum)                               \
     inline int Enum::initialize()                                              \
     {                                                                          \
-        if (BETTER_ENUMS__NS(Enum)::_initialized())                            \
+        if (BETTER_ENUMS_NS(Enum)::_initialized())                            \
             return 0;                                                          \
                                                                                \
-        ::better_enums::_trim_names(BETTER_ENUMS__NS(Enum)::_raw_names(),      \
-                                    BETTER_ENUMS__NS(Enum)::_name_array(),     \
-                                    BETTER_ENUMS__NS(Enum)::_name_storage(),   \
+        ::better_enums::_trim_names(BETTER_ENUMS_NS(Enum)::_raw_names(),      \
+                                    BETTER_ENUMS_NS(Enum)::_name_array(),     \
+                                    BETTER_ENUMS_NS(Enum)::_name_storage(),   \
                                     _size());                                  \
                                                                                \
-        BETTER_ENUMS__NS(Enum)::_initialized() = true;                         \
+        BETTER_ENUMS_NS(Enum)::_initialized() = true;                         \
                                                                                \
         return 0;                                                              \
     }
 
 // C++11 slow all-constexpr version
-#define BETTER_ENUMS__DO_NOT_DEFINE_INITIALIZE(Enum)
+#define BETTER_ENUMS_DO_NOT_DEFINE_INITIALIZE(Enum)
 
 // C++98, C++11 fast version
-#define BETTER_ENUMS__DO_CALL_INITIALIZE(value)                                \
+#define BETTER_ENUMS_DO_CALL_INITIALIZE(value)                                \
     ::better_enums::continue_with(initialize(), value)
 
 // C++11 slow all-constexpr version
-#define BETTER_ENUMS__DO_NOT_CALL_INITIALIZE(value)                            \
+#define BETTER_ENUMS_DO_NOT_CALL_INITIALIZE(value)                            \
     value
 
 
@@ -984,15 +984,15 @@ BETTER_ENUMS__CONSTEXPR inline bool operator >=(const Enum &a, const Enum &b)  \
 // User feature selection.
 
 #ifdef BETTER_ENUMS_STRICT_CONVERSION
-#   define BETTER_ENUMS__DEFAULT_SWITCH_TYPE                                   \
-        BETTER_ENUMS__ENUM_CLASS_SWITCH_TYPE
-#   define BETTER_ENUMS__DEFAULT_SWITCH_TYPE_GENERATE                          \
-        BETTER_ENUMS__ENUM_CLASS_SWITCH_TYPE_GENERATE
+#   define BETTER_ENUMS_DEFAULT_SWITCH_TYPE                                   \
+        BETTER_ENUMS_ENUM_CLASS_SWITCH_TYPE
+#   define BETTER_ENUMS_DEFAULT_SWITCH_TYPE_GENERATE                          \
+        BETTER_ENUMS_ENUM_CLASS_SWITCH_TYPE_GENERATE
 #else
-#   define BETTER_ENUMS__DEFAULT_SWITCH_TYPE                                   \
-        BETTER_ENUMS__REGULAR_ENUM_SWITCH_TYPE
-#   define BETTER_ENUMS__DEFAULT_SWITCH_TYPE_GENERATE                          \
-        BETTER_ENUMS__REGULAR_ENUM_SWITCH_TYPE_GENERATE
+#   define BETTER_ENUMS_DEFAULT_SWITCH_TYPE                                   \
+        BETTER_ENUMS_REGULAR_ENUM_SWITCH_TYPE
+#   define BETTER_ENUMS_DEFAULT_SWITCH_TYPE_GENERATE                          \
+        BETTER_ENUMS_REGULAR_ENUM_SWITCH_TYPE_GENERATE
 #endif
 
 
@@ -1005,30 +1005,30 @@ BETTER_ENUMS__CONSTEXPR inline bool operator >=(const Enum &a, const Enum &b)  \
 
 
 
-#ifdef BETTER_ENUMS__HAVE_CONSTEXPR
+#ifdef BETTER_ENUMS_HAVE_CONSTEXPR
 
 #ifdef BETTER_ENUMS_CONSTEXPR_TO_STRING
-#   define BETTER_ENUMS__DEFAULT_TRIM_STRINGS_ARRAYS                           \
-        BETTER_ENUMS__CXX11_FULL_CONSTEXPR_TRIM_STRINGS_ARRAYS
-#   define BETTER_ENUMS__DEFAULT_TO_STRING_KEYWORD                             \
-        BETTER_ENUMS__CONSTEXPR_TO_STRING_KEYWORD
-#   define BETTER_ENUMS__DEFAULT_DECLARE_INITIALIZE                            \
-        BETTER_ENUMS__DECLARE_EMPTY_INITIALIZE
-#   define BETTER_ENUMS__DEFAULT_DEFINE_INITIALIZE                             \
-        BETTER_ENUMS__DO_NOT_DEFINE_INITIALIZE
-#   define BETTER_ENUMS__DEFAULT_CALL_INITIALIZE                               \
-        BETTER_ENUMS__DO_NOT_CALL_INITIALIZE
+#   define BETTER_ENUMS_DEFAULT_TRIM_STRINGS_ARRAYS                           \
+        BETTER_ENUMS_CXX11_FULL_CONSTEXPR_TRIM_STRINGS_ARRAYS
+#   define BETTER_ENUMS_DEFAULT_TO_STRING_KEYWORD                             \
+        BETTER_ENUMS_CONSTEXPR_TO_STRING_KEYWORD
+#   define BETTER_ENUMS_DEFAULT_DECLARE_INITIALIZE                            \
+        BETTER_ENUMS_DECLARE_EMPTY_INITIALIZE
+#   define BETTER_ENUMS_DEFAULT_DEFINE_INITIALIZE                             \
+        BETTER_ENUMS_DO_NOT_DEFINE_INITIALIZE
+#   define BETTER_ENUMS_DEFAULT_CALL_INITIALIZE                               \
+        BETTER_ENUMS_DO_NOT_CALL_INITIALIZE
 #else
-#   define BETTER_ENUMS__DEFAULT_TRIM_STRINGS_ARRAYS                           \
-        BETTER_ENUMS__CXX11_PARTIAL_CONSTEXPR_TRIM_STRINGS_ARRAYS
-#   define BETTER_ENUMS__DEFAULT_TO_STRING_KEYWORD                             \
-        BETTER_ENUMS__NO_CONSTEXPR_TO_STRING_KEYWORD
-#   define BETTER_ENUMS__DEFAULT_DECLARE_INITIALIZE                            \
-        BETTER_ENUMS__DO_DECLARE_INITIALIZE
-#   define BETTER_ENUMS__DEFAULT_DEFINE_INITIALIZE                             \
-        BETTER_ENUMS__DO_DEFINE_INITIALIZE
-#   define BETTER_ENUMS__DEFAULT_CALL_INITIALIZE                               \
-        BETTER_ENUMS__DO_CALL_INITIALIZE
+#   define BETTER_ENUMS_DEFAULT_TRIM_STRINGS_ARRAYS                           \
+        BETTER_ENUMS_CXX11_PARTIAL_CONSTEXPR_TRIM_STRINGS_ARRAYS
+#   define BETTER_ENUMS_DEFAULT_TO_STRING_KEYWORD                             \
+        BETTER_ENUMS_NO_CONSTEXPR_TO_STRING_KEYWORD
+#   define BETTER_ENUMS_DEFAULT_DECLARE_INITIALIZE                            \
+        BETTER_ENUMS_DO_DECLARE_INITIALIZE
+#   define BETTER_ENUMS_DEFAULT_DEFINE_INITIALIZE                             \
+        BETTER_ENUMS_DO_DEFINE_INITIALIZE
+#   define BETTER_ENUMS_DEFAULT_CALL_INITIALIZE                               \
+        BETTER_ENUMS_DO_CALL_INITIALIZE
 #endif
 
 
@@ -1036,41 +1036,41 @@ BETTER_ENUMS__CONSTEXPR inline bool operator >=(const Enum &a, const Enum &b)  \
 // Top-level macros.
 
 #define BETTER_ENUM(Enum, Underlying, ...)                                     \
-    BETTER_ENUMS__ID(BETTER_ENUMS__TYPE(                                       \
-        BETTER_ENUMS__CXX11_UNDERLYING_TYPE,                                   \
-        BETTER_ENUMS__DEFAULT_SWITCH_TYPE,                                     \
-        BETTER_ENUMS__DEFAULT_SWITCH_TYPE_GENERATE,                            \
-        BETTER_ENUMS__DEFAULT_TRIM_STRINGS_ARRAYS,                             \
-        BETTER_ENUMS__DEFAULT_TO_STRING_KEYWORD,                               \
-        BETTER_ENUMS__DEFAULT_DECLARE_INITIALIZE,                              \
-        BETTER_ENUMS__DEFAULT_DEFINE_INITIALIZE,                               \
-        BETTER_ENUMS__DEFAULT_CALL_INITIALIZE,                                 \
+    BETTER_ENUMS_ID(BETTER_ENUMS_TYPE(                                       \
+        BETTER_ENUMS_CXX11_UNDERLYING_TYPE,                                   \
+        BETTER_ENUMS_DEFAULT_SWITCH_TYPE,                                     \
+        BETTER_ENUMS_DEFAULT_SWITCH_TYPE_GENERATE,                            \
+        BETTER_ENUMS_DEFAULT_TRIM_STRINGS_ARRAYS,                             \
+        BETTER_ENUMS_DEFAULT_TO_STRING_KEYWORD,                               \
+        BETTER_ENUMS_DEFAULT_DECLARE_INITIALIZE,                              \
+        BETTER_ENUMS_DEFAULT_DEFINE_INITIALIZE,                               \
+        BETTER_ENUMS_DEFAULT_CALL_INITIALIZE,                                 \
         Enum, Underlying, __VA_ARGS__))
 
 #define SLOW_ENUM(Enum, Underlying, ...)                                       \
-    BETTER_ENUMS__ID(BETTER_ENUMS__TYPE(                                       \
-        BETTER_ENUMS__CXX11_UNDERLYING_TYPE,                                   \
-        BETTER_ENUMS__DEFAULT_SWITCH_TYPE,                                     \
-        BETTER_ENUMS__DEFAULT_SWITCH_TYPE_GENERATE,                            \
-        BETTER_ENUMS__CXX11_FULL_CONSTEXPR_TRIM_STRINGS_ARRAYS,                \
-        BETTER_ENUMS__CONSTEXPR_TO_STRING_KEYWORD,                             \
-        BETTER_ENUMS__DECLARE_EMPTY_INITIALIZE,                                \
-        BETTER_ENUMS__DO_NOT_DEFINE_INITIALIZE,                                \
-        BETTER_ENUMS__DO_NOT_CALL_INITIALIZE,                                  \
+    BETTER_ENUMS_ID(BETTER_ENUMS_TYPE(                                       \
+        BETTER_ENUMS_CXX11_UNDERLYING_TYPE,                                   \
+        BETTER_ENUMS_DEFAULT_SWITCH_TYPE,                                     \
+        BETTER_ENUMS_DEFAULT_SWITCH_TYPE_GENERATE,                            \
+        BETTER_ENUMS_CXX11_FULL_CONSTEXPR_TRIM_STRINGS_ARRAYS,                \
+        BETTER_ENUMS_CONSTEXPR_TO_STRING_KEYWORD,                             \
+        BETTER_ENUMS_DECLARE_EMPTY_INITIALIZE,                                \
+        BETTER_ENUMS_DO_NOT_DEFINE_INITIALIZE,                                \
+        BETTER_ENUMS_DO_NOT_CALL_INITIALIZE,                                  \
         Enum, Underlying, __VA_ARGS__))
 
 #else
 
 #define BETTER_ENUM(Enum, Underlying, ...)                                     \
-    BETTER_ENUMS__ID(BETTER_ENUMS__TYPE(                                       \
-        BETTER_ENUMS__CXX98_UNDERLYING_TYPE,                                   \
-        BETTER_ENUMS__DEFAULT_SWITCH_TYPE,                                     \
-        BETTER_ENUMS__DEFAULT_SWITCH_TYPE_GENERATE,                            \
-        BETTER_ENUMS__CXX98_TRIM_STRINGS_ARRAYS,                               \
-        BETTER_ENUMS__NO_CONSTEXPR_TO_STRING_KEYWORD,                          \
-        BETTER_ENUMS__DO_DECLARE_INITIALIZE,                                   \
-        BETTER_ENUMS__DO_DEFINE_INITIALIZE,                                    \
-        BETTER_ENUMS__DO_CALL_INITIALIZE,                                      \
+    BETTER_ENUMS_ID(BETTER_ENUMS_TYPE(                                       \
+        BETTER_ENUMS_CXX98_UNDERLYING_TYPE,                                   \
+        BETTER_ENUMS_DEFAULT_SWITCH_TYPE,                                     \
+        BETTER_ENUMS_DEFAULT_SWITCH_TYPE_GENERATE,                            \
+        BETTER_ENUMS_CXX98_TRIM_STRINGS_ARRAYS,                               \
+        BETTER_ENUMS_NO_CONSTEXPR_TO_STRING_KEYWORD,                          \
+        BETTER_ENUMS_DO_DECLARE_INITIALIZE,                                   \
+        BETTER_ENUMS_DO_DEFINE_INITIALIZE,                                    \
+        BETTER_ENUMS_DO_CALL_INITIALIZE,                                      \
         Enum, Underlying, __VA_ARGS__))
 
 #endif
@@ -1083,17 +1083,17 @@ namespace better_enums {
 
 template <typename T>
 struct map_compare {
-    BETTER_ENUMS__CONSTEXPR static bool less(const T& a, const T& b)
+    BETTER_ENUMS_CONSTEXPR static bool less(const T& a, const T& b)
         { return a < b; }
 };
 
 template <>
 struct map_compare<const char*> {
-    BETTER_ENUMS__CONSTEXPR static bool less(const char *a, const char *b)
+    BETTER_ENUMS_CONSTEXPR static bool less(const char *a, const char *b)
         { return less_loop(a, b); }
 
   private:
-    BETTER_ENUMS__CONSTEXPR static bool
+    BETTER_ENUMS_CONSTEXPR static bool
     less_loop(const char *a, const char *b, size_t index = 0)
     {
         return
@@ -1107,19 +1107,19 @@ template <typename Enum, typename T, typename Compare = map_compare<T> >
 struct map {
     typedef T (*function)(Enum);
 
-    BETTER_ENUMS__CONSTEXPR explicit map(function f) : _f(f) { }
+    BETTER_ENUMS_CONSTEXPR explicit map(function f) : _f(f) { }
 
-    BETTER_ENUMS__CONSTEXPR T from_enum(Enum value) const { return _f(value); }
-    BETTER_ENUMS__CONSTEXPR T operator [](Enum value) const
+    BETTER_ENUMS_CONSTEXPR T from_enum(Enum value) const { return _f(value); }
+    BETTER_ENUMS_CONSTEXPR T operator [](Enum value) const
         { return _f(value); }
 
-    BETTER_ENUMS__CONSTEXPR Enum to_enum(T value) const
+    BETTER_ENUMS_CONSTEXPR Enum to_enum(T value) const
     {
         return
             _or_throw(to_enum_nothrow(value), "map::to_enum: invalid argument");
     }
 
-    BETTER_ENUMS__CONSTEXPR optional<Enum>
+    BETTER_ENUMS_CONSTEXPR optional<Enum>
     to_enum_nothrow(T value, size_t index = 0) const
     {
         return
@@ -1135,7 +1135,7 @@ struct map {
 };
 
 template <typename Enum, typename T>
-BETTER_ENUMS__CONSTEXPR map<Enum, T> make_map(T (*f)(Enum))
+BETTER_ENUMS_CONSTEXPR map<Enum, T> make_map(T (*f)(Enum))
 {
     return map<Enum, T>(f);
 }
@@ -1181,4 +1181,4 @@ operator >>(std::basic_istream<Char, Traits>& stream, Enum &value)
 
 
 
-#endif // #ifndef BETTER_ENUMS__ENUM_H
+#endif // #ifndef BETTER_ENUMS_ENUM_H

--- a/extra/better-enums/n4428.h
+++ b/extra/better-enums/n4428.h
@@ -12,8 +12,8 @@
 
 #pragma once
 
-#ifndef BETTER_ENUMS__N4428_H
-#define BETTER_ENUMS__N4428_H
+#ifndef BETTER_ENUMS_N4428_H
+#define BETTER_ENUMS_N4428_H
 
 
 
@@ -49,4 +49,4 @@ struct enum_traits {
 
 
 
-#endif // #ifndef BETTER_ENUMS__N4428_H
+#endif // #ifndef BETTER_ENUMS_N4428_H

--- a/script/make_macros.py
+++ b/script/make_macros.py
@@ -5,14 +5,14 @@
 
 # You only need this script if you are developing enum.h, or run into a limit.
 #
-# This script generates the macros BETTER_ENUMS__PP_MAP and
-# BETTER_ENUMS__ITERATE, used internally by enum.h. These are already inlined
+# This script generates the macros BETTER_ENUMS_PP_MAP and
+# BETTER_ENUMS_ITERATE, used internally by enum.h. These are already inlined
 # into enum.h.
 #
-# BETTER_ENUMS__PP_MAP has a limit, which determines the maximum number of
+# BETTER_ENUMS_PP_MAP has a limit, which determines the maximum number of
 # constants an enum can have. By default, this limit is 64 constants.
 #
-# BETTER_ENUMS__ITERATE also has a limit. This one determines the maximum length
+# BETTER_ENUMS_ITERATE also has a limit. This one determines the maximum length
 # of the name of a constant that is followed by an initializer (" = 2") when
 # compiling an enum with constexpr _to_string function (i.e. usually, this limit
 # does not apply). By default, the limit is 23 characters (24 with the
@@ -68,38 +68,38 @@ def generate(stream, constants, length, script):
     print >> stream, ''
     print >> stream, '#pragma once'
     print >> stream, ''
-    print >> stream, '#ifndef BETTER_ENUMS__MACRO_FILE_H'
-    print >> stream, '#define BETTER_ENUMS__MACRO_FILE_H'
+    print >> stream, '#ifndef BETTER_ENUMS_MACRO_FILE_H'
+    print >> stream, '#define BETTER_ENUMS_MACRO_FILE_H'
 
     print >> stream, ''
-    print >> stream, '#define BETTER_ENUMS__PP_MAP(macro, data, ...) \\'
-    print >> stream, '    BETTER_ENUMS__ID( \\'
-    print >> stream, '        BETTER_ENUMS__APPLY( \\'
-    print >> stream, '            BETTER_ENUMS__PP_MAP_VAR_COUNT, \\'
-    print >> stream, '            BETTER_ENUMS__PP_COUNT(__VA_ARGS__)) \\'
+    print >> stream, '#define BETTER_ENUMS_PP_MAP(macro, data, ...) \\'
+    print >> stream, '    BETTER_ENUMS_ID( \\'
+    print >> stream, '        BETTER_ENUMS_APPLY( \\'
+    print >> stream, '            BETTER_ENUMS_PP_MAP_VAR_COUNT, \\'
+    print >> stream, '            BETTER_ENUMS_PP_COUNT(__VA_ARGS__)) \\'
     print >> stream, '        (macro, data, __VA_ARGS__))'
 
     print >> stream, ''
-    print >> stream, '#define BETTER_ENUMS__PP_MAP_VAR_COUNT(count) ' + \
-                     'BETTER_ENUMS__M ## count'
+    print >> stream, '#define BETTER_ENUMS_PP_MAP_VAR_COUNT(count) ' + \
+                     'BETTER_ENUMS_M ## count'
 
     print >> stream, ''
-    print >> stream, '#define BETTER_ENUMS__APPLY(macro, ...) ' + \
-                      'BETTER_ENUMS__ID(macro(__VA_ARGS__))'
+    print >> stream, '#define BETTER_ENUMS_APPLY(macro, ...) ' + \
+                      'BETTER_ENUMS_ID(macro(__VA_ARGS__))'
 
     print >> stream, ''
-    print >> stream, '#define BETTER_ENUMS__ID(x) x'
+    print >> stream, '#define BETTER_ENUMS_ID(x) x'
 
     print >> stream, ''
-    print >> stream, '#define BETTER_ENUMS__M1(m, d, x) m(d,0,x)'
+    print >> stream, '#define BETTER_ENUMS_M1(m, d, x) m(d,0,x)'
     for index in range(2, constants + 1):
-        print >> stream, '#define BETTER_ENUMS__M' + str(index) + \
+        print >> stream, '#define BETTER_ENUMS_M' + str(index) + \
                          '(m,d,x,...) m(d,' + str(index - 1) + ',x) \\'
-        print >> stream, '    BETTER_ENUMS__ID(BETTER_ENUMS__M' + \
+        print >> stream, '    BETTER_ENUMS_ID(BETTER_ENUMS_M' + \
                          str(index - 1) + '(m,d,__VA_ARGS__))'
 
     print >> stream, ''
-    pp_count_impl_prefix = '#define BETTER_ENUMS__PP_COUNT_IMPL(_1,'
+    pp_count_impl_prefix = '#define BETTER_ENUMS_PP_COUNT_IMPL(_1,'
     stream.write(pp_count_impl_prefix)
     pp_count_impl = MultiLine(stream = stream, indent = 4,
                               initial_column = len(pp_count_impl_prefix))
@@ -111,9 +111,9 @@ def generate(stream, constants, length, script):
     print >> stream, ''
 
     print >> stream, ''
-    print >> stream, '#define BETTER_ENUMS__PP_COUNT(...) \\'
+    print >> stream, '#define BETTER_ENUMS_PP_COUNT(...) \\'
     pp_count_prefix = \
-        '    BETTER_ENUMS__ID(BETTER_ENUMS__PP_COUNT_IMPL(__VA_ARGS__,'
+        '    BETTER_ENUMS_ID(BETTER_ENUMS_PP_COUNT_IMPL(__VA_ARGS__,'
     stream.write(pp_count_prefix)
     pp_count = MultiLine(stream = stream, indent = 8,
                          initial_column = len(pp_count_prefix))
@@ -123,7 +123,7 @@ def generate(stream, constants, length, script):
     print >> stream, ''
 
     print >> stream, ''
-    iterate_prefix = '#define BETTER_ENUMS__ITERATE(X, f, l)'
+    iterate_prefix = '#define BETTER_ENUMS_ITERATE(X, f, l)'
     stream.write(iterate_prefix)
     iterate = MultiLine(stream = stream, indent = 4,
                         initial_column = len(iterate_prefix))
@@ -132,7 +132,7 @@ def generate(stream, constants, length, script):
     print >> stream, ''
 
     print >> stream, ''
-    print >> stream, '#endif // #ifndef BETTER_ENUMS__MACRO_FILE_H'
+    print >> stream, '#endif // #ifndef BETTER_ENUMS_MACRO_FILE_H'
 
 if __name__ == '__main__':
     if len(sys.argv) != 3:

--- a/test/cxxtest/general.h
+++ b/test/cxxtest/general.h
@@ -28,7 +28,7 @@ BETTER_ENUM(Namespaced, short, One, Two)
 
 // Using _ENUM_HAVE_CONSTEXPR as a proxy for C++11 support. This should be
 // changed to be more precise in the future.
-#ifdef BETTER_ENUMS__HAVE_CONSTEXPR
+#ifdef BETTER_ENUMS_HAVE_CONSTEXPR
 
 #include <type_traits>
 


### PR DESCRIPTION
Latest CLang gives a heap of warnings "macro name is a reserved identifier". According to C++ standard identifiers with double underscore are reserved. This is my go at trying to fix it.