### PR TITLE
Fix /W4 level warnings in MSVC++ 2015

### DIFF
--- a/enum.h
+++ b/enum.h
@@ -886,7 +886,7 @@ operator >>(std::basic_istream<Char, Traits>& stream, Enum &value)             \
 #define BETTER_ENUMS_CXX11_UNDERLYING_TYPE(Underlying)                         \
     : Underlying
 
-#if !defined(_MSC_VER) || _MSC_VER >= 1700
+#if defined(_MSC_VER) && _MSC_VER >= 1700
 // VS 2012 and above fully support strongly typed enums and will warn about
 // incorrect usage.
 #   define BETTER_ENUMS_LEGACY_UNDERLYING_TYPE(Underlying) BETTER_ENUMS_CXX11_UNDERLYING_TYPE(Underlying)

--- a/enum.h
+++ b/enum.h
@@ -85,8 +85,10 @@
 
 #ifdef __GNUC__
 #   define BETTER_ENUMS_UNUSED __attribute__((__unused__))
+#   define BETTER_ENUMS_UNUSED_WRAPPER(x) x
 #else
 #   define BETTER_ENUMS_UNUSED
+#   define BETTER_ENUMS_UNUSED_WRAPPER(x)
 #endif
 
 
@@ -349,7 +351,7 @@ BETTER_ENUMS_CONSTEXPR_ static T* _or_null(optional<T*> maybe)
 
 template <typename T, typename U>
 BETTER_ENUMS_CONSTEXPR_ U
-continue_with(T ignored BETTER_ENUMS_UNUSED, U value) { return value; }
+continue_with(T BETTER_ENUMS_UNUSED_WRAPPER(ignored) BETTER_ENUMS_UNUSED, U value) { return value; }
 
 
 
@@ -362,7 +364,7 @@ struct _eat_assign {
 
     template <typename Any>
     BETTER_ENUMS_CONSTEXPR_ const _eat_assign&
-    operator =(Any dummy BETTER_ENUMS_UNUSED) const { return *this; }
+    operator =(Any BETTER_ENUMS_UNUSED_WRAPPER(dummy) BETTER_ENUMS_UNUSED) const { return *this; }
 
     BETTER_ENUMS_CONSTEXPR_ operator EnumType () const { return _value; }
 
@@ -886,6 +888,14 @@ operator >>(std::basic_istream<Char, Traits>& stream, Enum &value)             \
 #define BETTER_ENUMS_CXX11_UNDERLYING_TYPE(Underlying)                         \
     : Underlying
 
+#if _MSC_VER >= 1700
+// VS 2012 and above fully support strongly typed enums and will warn about
+// incorrect usage.
+#   define BETTER_ENUMS_LEGACY_UNDERLYING_TYPE(Underlying) BETTER_ENUMS_CXX11_UNDERLYING_TYPE(Underlying)
+#else
+#   define BETTER_ENUMS_LEGACY_UNDERLYING_TYPE(Underlying) BETTER_ENUMS_CXX98_UNDERLYING_TYPE(Underlying)
+#endif
+
 // C++98, C++11
 #define BETTER_ENUMS_REGULAR_ENUM_SWITCH_TYPE(Type)                            \
     _enumerated
@@ -1102,7 +1112,7 @@ operator >>(std::basic_istream<Char, Traits>& stream, Enum &value)             \
 
 #define BETTER_ENUM(Enum, Underlying, ...)                                     \
     BETTER_ENUMS_ID(BETTER_ENUMS_TYPE(                                         \
-        BETTER_ENUMS_CXX98_UNDERLYING_TYPE,                                    \
+        BETTER_ENUMS_LEGACY_UNDERLYING_TYPE,                                   \
         BETTER_ENUMS_DEFAULT_SWITCH_TYPE,                                      \
         BETTER_ENUMS_DEFAULT_SWITCH_TYPE_GENERATE,                             \
         BETTER_ENUMS_CXX98_TRIM_STRINGS_ARRAYS,                                \

--- a/enum.h
+++ b/enum.h
@@ -85,10 +85,8 @@
 
 #ifdef __GNUC__
 #   define BETTER_ENUMS_UNUSED __attribute__((__unused__))
-#   define BETTER_ENUMS_UNUSED_WRAPPER(x) x
 #else
 #   define BETTER_ENUMS_UNUSED
-#   define BETTER_ENUMS_UNUSED_WRAPPER(x)
 #endif
 
 
@@ -364,7 +362,7 @@ struct _eat_assign {
 
     template <typename Any>
     BETTER_ENUMS_CONSTEXPR_ const _eat_assign&
-    operator =(Any BETTER_ENUMS_UNUSED_WRAPPER(dummy) BETTER_ENUMS_UNUSED) const { return *this; }
+    operator =(Any) const { return *this; }
 
     BETTER_ENUMS_CONSTEXPR_ operator EnumType () const { return _value; }
 
@@ -888,14 +886,12 @@ operator >>(std::basic_istream<Char, Traits>& stream, Enum &value)             \
 #define BETTER_ENUMS_CXX11_UNDERLYING_TYPE(Underlying)                         \
     : Underlying
 
-#ifdef _MSC_VER
-#   if _MSC_VER >= 1700
+#if !defined(_MSC_VER) || _MSC_VER >= 1700
 // VS 2012 and above fully support strongly typed enums and will warn about
 // incorrect usage.
-#       define BETTER_ENUMS_LEGACY_UNDERLYING_TYPE(Underlying) BETTER_ENUMS_CXX11_UNDERLYING_TYPE(Underlying)
-#   else
-#       define BETTER_ENUMS_LEGACY_UNDERLYING_TYPE(Underlying) BETTER_ENUMS_CXX98_UNDERLYING_TYPE(Underlying)
-#   endif
+#   define BETTER_ENUMS_LEGACY_UNDERLYING_TYPE(Underlying) BETTER_ENUMS_CXX11_UNDERLYING_TYPE(Underlying)
+#else
+#   define BETTER_ENUMS_LEGACY_UNDERLYING_TYPE(Underlying) BETTER_ENUMS_CXX98_UNDERLYING_TYPE(Underlying)
 #endif
 
 // C++98, C++11

--- a/enum.h
+++ b/enum.h
@@ -351,7 +351,7 @@ BETTER_ENUMS_CONSTEXPR_ static T* _or_null(optional<T*> maybe)
 
 template <typename T, typename U>
 BETTER_ENUMS_CONSTEXPR_ U
-continue_with(T BETTER_ENUMS_UNUSED_WRAPPER(ignored) BETTER_ENUMS_UNUSED, U value) { return value; }
+continue_with(T, U value) { return value; }
 
 
 
@@ -888,12 +888,14 @@ operator >>(std::basic_istream<Char, Traits>& stream, Enum &value)             \
 #define BETTER_ENUMS_CXX11_UNDERLYING_TYPE(Underlying)                         \
     : Underlying
 
-#if _MSC_VER >= 1700
+#ifdef _MSC_VER
+#   if _MSC_VER >= 1700
 // VS 2012 and above fully support strongly typed enums and will warn about
 // incorrect usage.
-#   define BETTER_ENUMS_LEGACY_UNDERLYING_TYPE(Underlying) BETTER_ENUMS_CXX11_UNDERLYING_TYPE(Underlying)
-#else
-#   define BETTER_ENUMS_LEGACY_UNDERLYING_TYPE(Underlying) BETTER_ENUMS_CXX98_UNDERLYING_TYPE(Underlying)
+#       define BETTER_ENUMS_LEGACY_UNDERLYING_TYPE(Underlying) BETTER_ENUMS_CXX11_UNDERLYING_TYPE(Underlying)
+#   else
+#       define BETTER_ENUMS_LEGACY_UNDERLYING_TYPE(Underlying) BETTER_ENUMS_CXX98_UNDERLYING_TYPE(Underlying)
+#   endif
 #endif
 
 // C++98, C++11


### PR DESCRIPTION
Remove unused variable names and use underlying class for enum (VS 2012 and above support strongly typed enums and will warn about incorrect usage).