### PR TITLE
Added indexable properties on enums

### DIFF
--- a/enum.h
+++ b/enum.h
@@ -346,7 +346,7 @@ BETTER_ENUMS_CONSTEXPR_ static T* _or_null(optional<T*> maybe)
 template <typename T>
 BETTER_ENUMS_CONSTEXPR_ static T _or_zero(optional<T> maybe)
 {
-    return maybe ? *maybe : static_cast<T>(0);
+    return maybe ? *maybe : T::_from_integral_unchecked(0);
 }
 
 
@@ -675,7 +675,7 @@ class Enum {                                                                   \
                                                                                \
     BETTER_ENUMS_CONSTEXPR_ static _optional_index                             \
     _from_value_loop(_integral value, std::size_t index = 0);                  \
-    BETTER_ENUMS_CONSTEXPR_ static _optional_index                             \
+    BETTER_ENUMS_CONSTEXPR_ static _optional                                   \
     _from_index_loop(_integral value, std::size_t index = 0);                  \
     BETTER_ENUMS_CONSTEXPR_ static _optional_index                             \
     _from_string_loop(const char *name, std::size_t index = 0);                \
@@ -721,11 +721,9 @@ BETTER_ENUMS_CONSTEXPR_ inline Enum::_optional                                 \
 Enum::_from_index_loop(Enum::_integral value, std::size_t index)               \
 {                                                                              \
     return                                                                     \
-        index == _size() ?                                                     \
+        index >= _size() ?                                                     \
             _optional() :                                                      \
-            BETTER_ENUMS_NS(Enum)::index == value ?                            \
-                _optional(_value_array[index]) :                               \
-                _from_value_loop(value, index + 1);                            \
+             _optional(BETTER_ENUMS_NS(Enum)::_value_array[index]);            \
 }                                                                              \
                                                                                \
 BETTER_ENUMS_CONSTEXPR_ inline Enum::_optional_index                           \
@@ -757,7 +755,7 @@ BETTER_ENUMS_CONSTEXPR_ inline Enum::_integral Enum::_to_integral() const      \
                                                                                \
 BETTER_ENUMS_CONSTEXPR_ inline Enum::_integral Enum::_to_index() const         \
 {                                                                              \
-    return _from_value_loop(value)                                             \
+    return *_from_value_loop(_value);                                          \
 }                                                                              \
                                                                                \
 BETTER_ENUMS_CONSTEXPR_ inline Enum                                            \

--- a/enum.h
+++ b/enum.h
@@ -676,7 +676,7 @@ class Enum {                                                                   \
     BETTER_ENUMS_CONSTEXPR_ static _optional_index                             \
     _from_value_loop(_integral value, std::size_t index = 0);                  \
     BETTER_ENUMS_CONSTEXPR_ static _optional                                   \
-    _from_index_loop(_integral value);                                         \
+    _from_index_loop(std::size_t index);                                       \
     BETTER_ENUMS_CONSTEXPR_ static _optional_index                             \
     _from_string_loop(const char *name, std::size_t index = 0);                \
     BETTER_ENUMS_CONSTEXPR_ static _optional_index                             \
@@ -718,12 +718,12 @@ Enum::_from_value_loop(Enum::_integral value, std::size_t index)               \
 }                                                                              \
                                                                                \
 BETTER_ENUMS_CONSTEXPR_ inline Enum::_optional                                 \
-Enum::_from_index_loop(Enum::_integral value)                                  \
+Enum::_from_index_loop(std::size_t index)                                      \
 {                                                                              \
     return                                                                     \
-        value >= _size() ?                                                     \
+        index >= _size() ?                                                     \
             _optional() :                                                      \
-             _optional(BETTER_ENUMS_NS(Enum)::_value_array[value]);            \
+             _optional(BETTER_ENUMS_NS(Enum)::_value_array[index]);            \
 }                                                                              \
                                                                                \
 BETTER_ENUMS_CONSTEXPR_ inline Enum::_optional_index                           \

--- a/enum.h
+++ b/enum.h
@@ -624,12 +624,12 @@ class Enum {                                                                   \
 																	     	   \
     BETTER_ENUMS_CONSTEXPR_ std::size_t _to_index() const;   	               \
     BETTER_ENUMS_IF_EXCEPTIONS(                                                \
-    BETTER_ENUMS_CONSTEXPR_ static Enum _from_index(_integral value);          \
+    BETTER_ENUMS_CONSTEXPR_ static Enum _from_index(std::size_t value);        \
     )                                                                          \
     BETTER_ENUMS_CONSTEXPR_ static Enum                                        \
-    _from_index_unchecked(_integral value);                                    \
+    _from_index_unchecked(std::size_t value);                                  \
     BETTER_ENUMS_CONSTEXPR_ static _optional                                   \
-    _from_index_nothrow(_integral value);                                      \
+    _from_index_nothrow(std::size_t value);                                    \
                                                                                \
     ToStringConstexpr const char* _to_string() const;                          \
     BETTER_ENUMS_IF_EXCEPTIONS(                                                \
@@ -759,23 +759,23 @@ BETTER_ENUMS_CONSTEXPR_ inline std::size_t Enum::_to_index() const             \
 }                                                                              \
                                                                                \
 BETTER_ENUMS_CONSTEXPR_ inline Enum                                            \
-Enum::_from_index_unchecked(_integral value)                                   \
+Enum::_from_index_unchecked(std::size_t index)                                 \
 {                                                                              \
     return                                                                     \
-        ::better_enums::_or_zero(_from_index_nothrow(value));                  \
+        ::better_enums::_or_zero(_from_index_nothrow(index));                  \
 }                                                                              \
                                                                                \
 BETTER_ENUMS_CONSTEXPR_ inline Enum::_optional                                 \
-Enum::_from_index_nothrow(_integral value)                                     \
+Enum::_from_index_nothrow(std::size_t index)                                   \
 {                                                                              \
-    return _from_index_loop(value);                                            \
+    return _from_index_loop(index);                                            \
 }                                                                              \
                                                                                \
 BETTER_ENUMS_IF_EXCEPTIONS(                                                    \
-BETTER_ENUMS_CONSTEXPR_ inline Enum Enum::_from_index(_integral value)         \
+BETTER_ENUMS_CONSTEXPR_ inline Enum Enum::_from_index(std::size_t index)       \
 {                                                                              \
     return                                                                     \
-        ::better_enums::_or_throw(_from_index_nothrow(value),                  \
+        ::better_enums::_or_throw(_from_index_nothrow(index),                  \
                                   #Enum "::_from_index: invalid argument");    \
 }                                                                              \
 )                                                                              \

--- a/enum.h
+++ b/enum.h
@@ -621,8 +621,8 @@ class Enum {                                                                   \
     _from_integral_unchecked(_integral value);                                 \
     BETTER_ENUMS_CONSTEXPR_ static _optional                                   \
     _from_integral_nothrow(_integral value);                                   \
-																			   \
-    BETTER_ENUMS_CONSTEXPR_ _integral _to_index() const;   	                   \
+																	     	   \
+    BETTER_ENUMS_CONSTEXPR_ std::size_t _to_index() const;   	               \
     BETTER_ENUMS_IF_EXCEPTIONS(                                                \
     BETTER_ENUMS_CONSTEXPR_ static Enum _from_index(_integral value);          \
     )                                                                          \
@@ -753,7 +753,7 @@ BETTER_ENUMS_CONSTEXPR_ inline Enum::_integral Enum::_to_integral() const      \
     return _integral(_value);                                                  \
 }                                                                              \
                                                                                \
-BETTER_ENUMS_CONSTEXPR_ inline Enum::_integral Enum::_to_index() const         \
+BETTER_ENUMS_CONSTEXPR_ inline std::size_t Enum::_to_index() const             \
 {                                                                              \
     return *_from_value_loop(_value);                                          \
 }                                                                              \

--- a/enum.h
+++ b/enum.h
@@ -676,7 +676,7 @@ class Enum {                                                                   \
     BETTER_ENUMS_CONSTEXPR_ static _optional_index                             \
     _from_value_loop(_integral value, std::size_t index = 0);                  \
     BETTER_ENUMS_CONSTEXPR_ static _optional                                   \
-    _from_index_loop(_integral value, std::size_t index = 0);                  \
+    _from_index_loop(_integral value);                                         \
     BETTER_ENUMS_CONSTEXPR_ static _optional_index                             \
     _from_string_loop(const char *name, std::size_t index = 0);                \
     BETTER_ENUMS_CONSTEXPR_ static _optional_index                             \
@@ -718,12 +718,12 @@ Enum::_from_value_loop(Enum::_integral value, std::size_t index)               \
 }                                                                              \
                                                                                \
 BETTER_ENUMS_CONSTEXPR_ inline Enum::_optional                                 \
-Enum::_from_index_loop(Enum::_integral value, std::size_t index)               \
+Enum::_from_index_loop(Enum::_integral value)                                  \
 {                                                                              \
     return                                                                     \
         index >= _size() ?                                                     \
             _optional() :                                                      \
-             _optional(BETTER_ENUMS_NS(Enum)::_value_array[index]);            \
+             _optional(BETTER_ENUMS_NS(Enum)::_value_array[value]);            \
 }                                                                              \
                                                                                \
 BETTER_ENUMS_CONSTEXPR_ inline Enum::_optional_index                           \

--- a/enum.h
+++ b/enum.h
@@ -675,8 +675,6 @@ class Enum {                                                                   \
                                                                                \
     BETTER_ENUMS_CONSTEXPR_ static _optional_index                             \
     _from_value_loop(_integral value, std::size_t index = 0);                  \
-    BETTER_ENUMS_CONSTEXPR_ static _optional                                   \
-    _from_index_loop(std::size_t index);                                       \
     BETTER_ENUMS_CONSTEXPR_ static _optional_index                             \
     _from_string_loop(const char *name, std::size_t index = 0);                \
     BETTER_ENUMS_CONSTEXPR_ static _optional_index                             \
@@ -715,15 +713,6 @@ Enum::_from_value_loop(Enum::_integral value, std::size_t index)               \
             BETTER_ENUMS_NS(Enum)::_value_array[index]._value == value ?       \
                 _optional_index(index) :                                       \
                 _from_value_loop(value, index + 1);                            \
-}                                                                              \
-                                                                               \
-BETTER_ENUMS_CONSTEXPR_ inline Enum::_optional                                 \
-Enum::_from_index_loop(std::size_t index)                                      \
-{                                                                              \
-    return                                                                     \
-        index >= _size() ?                                                     \
-            _optional() :                                                      \
-             _optional(BETTER_ENUMS_NS(Enum)::_value_array[index]);            \
 }                                                                              \
                                                                                \
 BETTER_ENUMS_CONSTEXPR_ inline Enum::_optional_index                           \
@@ -768,7 +757,10 @@ Enum::_from_index_unchecked(std::size_t index)                                 \
 BETTER_ENUMS_CONSTEXPR_ inline Enum::_optional                                 \
 Enum::_from_index_nothrow(std::size_t index)                                   \
 {                                                                              \
-    return _from_index_loop(index);                                            \
+    return                                                                     \
+        index >= _size() ?                                                     \
+            _optional() :                                                      \
+             _optional(BETTER_ENUMS_NS(Enum)::_value_array[index]);            \
 }                                                                              \
                                                                                \
 BETTER_ENUMS_IF_EXCEPTIONS(                                                    \

--- a/enum.h
+++ b/enum.h
@@ -343,6 +343,12 @@ BETTER_ENUMS_CONSTEXPR_ static T* _or_null(optional<T*> maybe)
     return maybe ? *maybe : BETTER_ENUMS_NULLPTR;
 }
 
+template <typename T>
+BETTER_ENUMS_CONSTEXPR_ static T _or_zero(optional<T> maybe)
+{
+    return maybe ? *maybe : static_cast<T>(0);
+}
+
 
 
 // Functional sequencing. This is essentially a comma operator wrapped in a
@@ -615,6 +621,15 @@ class Enum {                                                                   \
     _from_integral_unchecked(_integral value);                                 \
     BETTER_ENUMS_CONSTEXPR_ static _optional                                   \
     _from_integral_nothrow(_integral value);                                   \
+																			   \
+    BETTER_ENUMS_CONSTEXPR_ _integral _to_index() const;   	                   \
+    BETTER_ENUMS_IF_EXCEPTIONS(                                                \
+    BETTER_ENUMS_CONSTEXPR_ static Enum _from_index(_integral value);          \
+    )                                                                          \
+    BETTER_ENUMS_CONSTEXPR_ static Enum                                        \
+    _from_index_unchecked(_integral value);                                    \
+    BETTER_ENUMS_CONSTEXPR_ static _optional                                   \
+    _from_index_nothrow(_integral value);                                      \
                                                                                \
     ToStringConstexpr const char* _to_string() const;                          \
     BETTER_ENUMS_IF_EXCEPTIONS(                                                \
@@ -661,6 +676,8 @@ class Enum {                                                                   \
     BETTER_ENUMS_CONSTEXPR_ static _optional_index                             \
     _from_value_loop(_integral value, std::size_t index = 0);                  \
     BETTER_ENUMS_CONSTEXPR_ static _optional_index                             \
+    _from_index_loop(_integral value, std::size_t index = 0);                  \
+    BETTER_ENUMS_CONSTEXPR_ static _optional_index                             \
     _from_string_loop(const char *name, std::size_t index = 0);                \
     BETTER_ENUMS_CONSTEXPR_ static _optional_index                             \
     _from_string_nocase_loop(const char *name, std::size_t index = 0);         \
@@ -700,6 +717,17 @@ Enum::_from_value_loop(Enum::_integral value, std::size_t index)               \
                 _from_value_loop(value, index + 1);                            \
 }                                                                              \
                                                                                \
+BETTER_ENUMS_CONSTEXPR_ inline Enum::_optional                                 \
+Enum::_from_index_loop(Enum::_integral value, std::size_t index)               \
+{                                                                              \
+    return                                                                     \
+        index == _size() ?                                                     \
+            _optional() :                                                      \
+            BETTER_ENUMS_NS(Enum)::index == value ?                            \
+                _optional(_value_array[index]) :                               \
+                _from_value_loop(value, index + 1);                            \
+}                                                                              \
+                                                                               \
 BETTER_ENUMS_CONSTEXPR_ inline Enum::_optional_index                           \
 Enum::_from_string_loop(const char *name, std::size_t index)                   \
 {                                                                              \
@@ -726,6 +754,33 @@ BETTER_ENUMS_CONSTEXPR_ inline Enum::_integral Enum::_to_integral() const      \
 {                                                                              \
     return _integral(_value);                                                  \
 }                                                                              \
+                                                                               \
+BETTER_ENUMS_CONSTEXPR_ inline Enum::_integral Enum::_to_index() const         \
+{                                                                              \
+    return _from_value_loop(value)                                             \
+}                                                                              \
+                                                                               \
+BETTER_ENUMS_CONSTEXPR_ inline Enum                                            \
+Enum::_from_index_unchecked(_integral value)                                   \
+{                                                                              \
+    return                                                                     \
+        ::better_enums::_or_zero(_from_index_nothrow(value));                  \
+}                                                                              \
+                                                                               \
+BETTER_ENUMS_CONSTEXPR_ inline Enum::_optional                                 \
+Enum::_from_index_nothrow(_integral value)                                     \
+{                                                                              \
+    return _from_index_loop(value);                                            \
+}                                                                              \
+                                                                               \
+BETTER_ENUMS_IF_EXCEPTIONS(                                                    \
+BETTER_ENUMS_CONSTEXPR_ inline Enum Enum::_from_index(_integral value)         \
+{                                                                              \
+    return                                                                     \
+        ::better_enums::_or_throw(_from_index_nothrow(value),                  \
+                                  #Enum "::_from_index: invalid argument");    \
+}                                                                              \
+)                                                                              \
                                                                                \
 BETTER_ENUMS_CONSTEXPR_ inline Enum                                            \
 Enum::_from_integral_unchecked(_integral value)                                \

--- a/enum.h
+++ b/enum.h
@@ -721,7 +721,7 @@ BETTER_ENUMS_CONSTEXPR_ inline Enum::_optional                                 \
 Enum::_from_index_loop(Enum::_integral value)                                  \
 {                                                                              \
     return                                                                     \
-        index >= _size() ?                                                     \
+        value >= _size() ?                                                     \
             _optional() :                                                      \
              _optional(BETTER_ENUMS_NS(Enum)::_value_array[value]);            \
 }                                                                              \

--- a/test/cxxtest/general.h
+++ b/test/cxxtest/general.h
@@ -330,12 +330,12 @@ class EnumTests : public CxxTest::TestSuite {
 	
 	void test_from_index()
 	{
-        TS_ASSERT_EQUALS((+Channel::Red)), Depth::_from_index(0));
+        TS_ASSERT_EQUALS((+Channel::Red), Depth::_from_index(0));
         TS_ASSERT_EQUALS((+Channel::Green), Depth::_from_index(1));
         TS_ASSERT_EQUALS((+Channel::Blue), Depth::_from_index(1));
         TS_ASSERT_THROWS(Channel::_from_index(42), std::runtime_error);
 		
-        TS_ASSERT_EQUALS((+Depth::HighColor)), Depth::_from_index(0));
+        TS_ASSERT_EQUALS((+Depth::HighColor), Depth::_from_index(0));
         TS_ASSERT_EQUALS((+Depth::TrueColor), Depth::_from_index(1));
         TS_ASSERT_THROWS(Depth::_from_index(42), std::runtime_error);
 		

--- a/test/cxxtest/general.h
+++ b/test/cxxtest/general.h
@@ -330,9 +330,9 @@ class EnumTests : public CxxTest::TestSuite {
 	
 	void test_from_index()
 	{
-        TS_ASSERT_EQUALS((+Channel::Red), Depth::_from_index(0));
-        TS_ASSERT_EQUALS((+Channel::Green), Depth::_from_index(1));
-        TS_ASSERT_EQUALS((+Channel::Blue), Depth::_from_index(1));
+        TS_ASSERT_EQUALS((+Channel::Red), Channel::_from_index(0));
+        TS_ASSERT_EQUALS((+Channel::Green), Channel::_from_index(1));
+        TS_ASSERT_EQUALS((+Channel::Blue), Channel::_from_index(2));
         TS_ASSERT_THROWS(Channel::_from_index(42), std::runtime_error);
 		
         TS_ASSERT_EQUALS((+Depth::HighColor), Depth::_from_index(0));
@@ -358,7 +358,9 @@ class EnumTests : public CxxTest::TestSuite {
 		maybe_channel = Channel::_from_index(2);
         TS_ASSERT(maybe_channel);
         TS_ASSERT_EQUALS(*maybe_channel, +Channel::Blue);
-		TS_ASSERT(!Channel::_from_index(45));
+
+		maybe_channel = Channel::_from_index(45);
+		TS_ASSERT(!maybe_channel);
 		
 		better_enums::optional<Depth> maybe_depth = Depth::_from_index(0);
         TS_ASSERT(maybe_depth);
@@ -367,7 +369,9 @@ class EnumTests : public CxxTest::TestSuite {
 		maybe_depth = Depth::_from_index(1);
         TS_ASSERT(maybe_depth);
         TS_ASSERT_EQUALS(*maybe_depth, +Depth::TrueColor);
-		TS_ASSERT(!Channel::_from_index(45));
+
+		maybe_depth = Depth::_from_index(45);
+		TS_ASSERT(!maybe_depth);
 
 		better_enums::optional<Compression> maybe_compression = Compression::_from_index(0);
         TS_ASSERT(maybe_compression);
@@ -380,7 +384,9 @@ class EnumTests : public CxxTest::TestSuite {
 		maybe_compression = Compression::_from_index(2);
         TS_ASSERT(maybe_compression);
         TS_ASSERT_EQUALS(*maybe_compression, +Compression::Default);
-		TS_ASSERT(!Compression::_from_index(45));
+
+		maybe_compression = Compression::_from_index(45);
+		TS_ASSERT(!maybe_compression);
     }
 	
 	void test_from_index_unchecked()

--- a/test/cxxtest/general.h
+++ b/test/cxxtest/general.h
@@ -313,6 +313,103 @@ class EnumTests : public CxxTest::TestSuite {
                          +test::Namespaced::One);
         TS_ASSERT_EQUALS(strcmp(*test::Namespaced::_names().begin(), "One"), 0);
     }
+	
+    void test_to_index()
+    {
+        TS_ASSERT_EQUALS((+Channel::Red)._to_index(), 0);
+        TS_ASSERT_EQUALS((+Channel::Green)._to_index(), 1);
+        TS_ASSERT_EQUALS((+Channel::Blue)._to_index(), 2);
+		
+        TS_ASSERT_EQUALS((+Depth::HighColor)._to_index(), 0);
+        TS_ASSERT_EQUALS((+Depth::TrueColor)._to_index(), 1);
+		
+        TS_ASSERT_EQUALS((+Compression::None)._to_index(), 0);
+        TS_ASSERT_EQUALS((+Compression::Huffman)._to_index(), 1);
+        TS_ASSERT_EQUALS((+Compression::Default)._to_index(), 2);
+    }
+	
+	void test_from_index()
+	{
+        TS_ASSERT_EQUALS((+Channel::Red)), Depth::_from_index(0));
+        TS_ASSERT_EQUALS((+Channel::Green), Depth::_from_index(1));
+        TS_ASSERT_EQUALS((+Channel::Blue), Depth::_from_index(1));
+        TS_ASSERT_THROWS(Channel::_from_index(42), std::runtime_error);
+		
+        TS_ASSERT_EQUALS((+Depth::HighColor)), Depth::_from_index(0));
+        TS_ASSERT_EQUALS((+Depth::TrueColor), Depth::_from_index(1));
+        TS_ASSERT_THROWS(Depth::_from_index(42), std::runtime_error);
+		
+        TS_ASSERT_EQUALS((+Compression::None), Compression::_from_index(0));
+        TS_ASSERT_EQUALS((+Compression::Huffman), Compression::_from_index(1));
+        TS_ASSERT_EQUALS((+Compression::Default), Compression::_from_index(2));
+        TS_ASSERT_THROWS(Compression::_from_index(42), std::runtime_error);
+	}
+	
+    void test_from_index_nothrow()
+    {
+		better_enums::optional<Channel> maybe_channel = Channel::_from_index(0);
+        TS_ASSERT(maybe_channel);
+        TS_ASSERT_EQUALS(*maybe_channel, +Channel::Red);
+		
+		maybe_channel = Channel::_from_index(1);
+        TS_ASSERT(maybe_channel);
+        TS_ASSERT_EQUALS(*maybe_channel, +Channel::Green);
+		
+		maybe_channel = Channel::_from_index(2);
+        TS_ASSERT(maybe_channel);
+        TS_ASSERT_EQUALS(*maybe_channel, +Channel::Blue);
+		TS_ASSERT(!Channel::_from_index(45));
+		
+		better_enums::optional<Depth> maybe_depth = Depth::_from_index(0);
+        TS_ASSERT(maybe_depth);
+        TS_ASSERT_EQUALS(*maybe_depth, +Depth::HighColor);
+		
+		maybe_depth = Depth::_from_index(1);
+        TS_ASSERT(maybe_depth);
+        TS_ASSERT_EQUALS(*maybe_depth, +Depth::TrueColor);
+		TS_ASSERT(!Channel::_from_index(45));
+		
+		better_enums::optional<Depth> maybe_depth = Depth::_from_index(0);
+        TS_ASSERT(maybe_depth);
+        TS_ASSERT_EQUALS(*maybe_depth, +Depth::HighColor);
+		
+		maybe_depth = Depth::_from_index(1);
+        TS_ASSERT(maybe_depth);
+        TS_ASSERT_EQUALS(*maybe_depth, +Depth::TrueColor);
+		TS_ASSERT(!Channel::_from_index(45));
+		
+		better_enums::optional<Depth> maybe_depth = Depth::_from_index(0);
+        TS_ASSERT(maybe_depth);
+        TS_ASSERT_EQUALS(*maybe_depth, +Depth::HighColor);
+		
+		better_enums::optional<Compression> maybe_compression = Compression::_from_index(0);
+        TS_ASSERT(maybe_compression);
+        TS_ASSERT_EQUALS(*maybe_compression, +Compression::None);
+		
+		maybe_compression = Compression::_from_index(1);
+        TS_ASSERT(maybe_compression);
+        TS_ASSERT_EQUALS(*maybe_compression, +Compression::Huffman);
+		
+		maybe_compression = Compression::_from_index(2);
+        TS_ASSERT(maybe_compression);
+        TS_ASSERT_EQUALS(*maybe_compression, +Compression::Default);
+		TS_ASSERT(!Compression::_from_index(45));
+    }
+	
+	void test_from_index_unchecked()
+	{
+		
+        TS_ASSERT_EQUALS((+Channel::Red), Channel::_from_index_unchecked(0));
+        TS_ASSERT_EQUALS((+Channel::Green), Channel::_from_index_unchecked(1));
+        TS_ASSERT_EQUALS((+Channel::Blue), Channel::_from_index_unchecked(2));
+		
+        TS_ASSERT_EQUALS((+Depth::HighColor)), Depth::_from_index_unchecked(0));
+        TS_ASSERT_EQUALS((+Depth::TrueColor), Depth::_from_index_unchecked(1));
+		
+        TS_ASSERT_EQUALS((+Compression::None), Compression::_from_index_unchecked(0));
+        TS_ASSERT_EQUALS((+Compression::Huffman), Compression::_from_index_unchecked(1));
+        TS_ASSERT_EQUALS((+Compression::Default), Compression::_from_index_unchecked(2));
+	}
 };
 
 

--- a/test/cxxtest/general.h
+++ b/test/cxxtest/general.h
@@ -368,20 +368,7 @@ class EnumTests : public CxxTest::TestSuite {
         TS_ASSERT(maybe_depth);
         TS_ASSERT_EQUALS(*maybe_depth, +Depth::TrueColor);
 		TS_ASSERT(!Channel::_from_index(45));
-		
-		better_enums::optional<Depth> maybe_depth = Depth::_from_index(0);
-        TS_ASSERT(maybe_depth);
-        TS_ASSERT_EQUALS(*maybe_depth, +Depth::HighColor);
-		
-		maybe_depth = Depth::_from_index(1);
-        TS_ASSERT(maybe_depth);
-        TS_ASSERT_EQUALS(*maybe_depth, +Depth::TrueColor);
-		TS_ASSERT(!Channel::_from_index(45));
-		
-		better_enums::optional<Depth> maybe_depth = Depth::_from_index(0);
-        TS_ASSERT(maybe_depth);
-        TS_ASSERT_EQUALS(*maybe_depth, +Depth::HighColor);
-		
+
 		better_enums::optional<Compression> maybe_compression = Compression::_from_index(0);
         TS_ASSERT(maybe_compression);
         TS_ASSERT_EQUALS(*maybe_compression, +Compression::None);
@@ -403,7 +390,7 @@ class EnumTests : public CxxTest::TestSuite {
         TS_ASSERT_EQUALS((+Channel::Green), Channel::_from_index_unchecked(1));
         TS_ASSERT_EQUALS((+Channel::Blue), Channel::_from_index_unchecked(2));
 		
-        TS_ASSERT_EQUALS((+Depth::HighColor)), Depth::_from_index_unchecked(0));
+        TS_ASSERT_EQUALS((+Depth::HighColor), Depth::_from_index_unchecked(0));
         TS_ASSERT_EQUALS((+Depth::TrueColor), Depth::_from_index_unchecked(1));
 		
         TS_ASSERT_EQUALS((+Compression::None), Compression::_from_index_unchecked(0));

--- a/test/cxxtest/general.h
+++ b/test/cxxtest/general.h
@@ -325,7 +325,7 @@ class EnumTests : public CxxTest::TestSuite {
 		
         TS_ASSERT_EQUALS((+Compression::None)._to_index(), 0);
         TS_ASSERT_EQUALS((+Compression::Huffman)._to_index(), 1);
-        TS_ASSERT_EQUALS((+Compression::Default)._to_index(), 2);
+//        TS_ASSERT_EQUALS((+Compression::Default)._to_index(), 2); // This won't pass as Compression::Huffman == Compression::Default
     }
 	
 	void test_from_index()
@@ -347,45 +347,45 @@ class EnumTests : public CxxTest::TestSuite {
 	
     void test_from_index_nothrow()
     {
-		better_enums::optional<Channel> maybe_channel = Channel::_from_index(0);
+		better_enums::optional<Channel> maybe_channel = Channel::_from_index_nothrow(0);
         TS_ASSERT(maybe_channel);
         TS_ASSERT_EQUALS(*maybe_channel, +Channel::Red);
 		
-		maybe_channel = Channel::_from_index(1);
+		maybe_channel = Channel::_from_index_nothrow(1);
         TS_ASSERT(maybe_channel);
         TS_ASSERT_EQUALS(*maybe_channel, +Channel::Green);
 		
-		maybe_channel = Channel::_from_index(2);
+		maybe_channel = Channel::_from_index_nothrow(2);
         TS_ASSERT(maybe_channel);
         TS_ASSERT_EQUALS(*maybe_channel, +Channel::Blue);
 
-		maybe_channel = Channel::_from_index(45);
+		maybe_channel = Channel::_from_index_nothrow(45);
 		TS_ASSERT(!maybe_channel);
 		
-		better_enums::optional<Depth> maybe_depth = Depth::_from_index(0);
+		better_enums::optional<Depth> maybe_depth = Depth::_from_index_nothrow(0);
         TS_ASSERT(maybe_depth);
         TS_ASSERT_EQUALS(*maybe_depth, +Depth::HighColor);
 		
-		maybe_depth = Depth::_from_index(1);
+		maybe_depth = Depth::_from_index_nothrow(1);
         TS_ASSERT(maybe_depth);
         TS_ASSERT_EQUALS(*maybe_depth, +Depth::TrueColor);
 
-		maybe_depth = Depth::_from_index(45);
+		maybe_depth = Depth::_from_index_nothrow(45);
 		TS_ASSERT(!maybe_depth);
 
-		better_enums::optional<Compression> maybe_compression = Compression::_from_index(0);
+		better_enums::optional<Compression> maybe_compression = Compression::_from_index_nothrow(0);
         TS_ASSERT(maybe_compression);
         TS_ASSERT_EQUALS(*maybe_compression, +Compression::None);
 		
-		maybe_compression = Compression::_from_index(1);
+		maybe_compression = Compression::_from_index_nothrow(1);
         TS_ASSERT(maybe_compression);
         TS_ASSERT_EQUALS(*maybe_compression, +Compression::Huffman);
 		
-		maybe_compression = Compression::_from_index(2);
+		maybe_compression = Compression::_from_index_nothrow(2);
         TS_ASSERT(maybe_compression);
         TS_ASSERT_EQUALS(*maybe_compression, +Compression::Default);
 
-		maybe_compression = Compression::_from_index(45);
+		maybe_compression = Compression::_from_index_nothrow(45);
 		TS_ASSERT(!maybe_compression);
     }
 	


### PR DESCRIPTION
 - _to_index which always return value 0... size-1
        (even if enums are not sequential)
 - _from_index used for other way around
 - _from_index_nothrow no throw version
 - _from_index_unchecked returns invalid enum
        in case arg>=size

Code and test cases added.
No documentation updates (my English is too poor for that)

Usage case:

```{cpp}
BETTER_ENUM(Enum, int, A = 128, B = 256, C = 1024)
for(int i = 0; i < Enum::_size(); i++)
{
    Enum foo = Enum::_from_index_unchecked(i);
    printf("%d enum is %s \n", i, foo._to_string());
}
```