### PR TITLE
Renamed identifiers beginning with underscore followed by uppercase letters

### DIFF
--- a/enum.h
+++ b/enum.h
@@ -384,7 +384,7 @@ struct _eat_assign {
 // Iterables.
 
 template <typename Element>
-struct _Iterable {
+struct _iterable {
     typedef const Element*  iterator;
 
     BETTER_ENUMS_CONSTEXPR_ iterator begin() const { return iterator(_array); }
@@ -394,7 +394,7 @@ struct _Iterable {
     BETTER_ENUMS_CONSTEXPR_ const Element& operator [](std::size_t index) const
         { return _array[index]; }
 
-    BETTER_ENUMS_CONSTEXPR_ _Iterable(const Element *array, std::size_t s) :
+    BETTER_ENUMS_CONSTEXPR_ _iterable(const Element *array, std::size_t s) :
         _array(array), _size(s) { }
 
   private:
@@ -648,8 +648,8 @@ class Enum {                                                                   \
     BETTER_ENUMS_CONSTEXPR_ static bool _is_valid(const char *name);           \
     BETTER_ENUMS_CONSTEXPR_ static bool _is_valid_nocase(const char *name);    \
                                                                                \
-    typedef ::better_enums::_Iterable<Enum>             _value_iterable;       \
-    typedef ::better_enums::_Iterable<const char*>      _name_iterable;        \
+    typedef ::better_enums::_iterable<Enum>             _value_iterable;       \
+    typedef ::better_enums::_iterable<const char*>      _name_iterable;        \
                                                                                \
     typedef _value_iterable::iterator                   _value_iterator;       \
     typedef _name_iterable::iterator                    _name_iterator;        \
@@ -688,7 +688,7 @@ namespace better_enums_data_ ## Enum {                                         \
 static ::better_enums::_initialize_at_program_start<Enum>                      \
                                                 _force_initialization;         \
                                                                                \
-enum _PutNamesInThisScopeAlso { __VA_ARGS__ };                                 \
+enum _putNamesInThisScopeAlso { __VA_ARGS__ };                                 \
                                                                                \
 BETTER_ENUMS_CONSTEXPR_ const Enum      _value_array[] =                       \
     { BETTER_ENUMS_ID(BETTER_ENUMS_EAT_ASSIGN(Enum, __VA_ARGS__)) };           \
@@ -948,14 +948,14 @@ operator >>(std::basic_istream<Char, Traits>& stream, Enum &value)             \
 
 // C++11
 #define BETTER_ENUMS_ENUM_CLASS_SWITCH_TYPE(Type)                              \
-    BETTER_ENUMS_NS(Type)::_EnumClassForSwitchStatements
+    BETTER_ENUMS_NS(Type)::_enumClassForSwitchStatements
 
 // C++98, C++11
 #define BETTER_ENUMS_REGULAR_ENUM_SWITCH_TYPE_GENERATE(Underlying, ...)
 
 // C++11
 #define BETTER_ENUMS_ENUM_CLASS_SWITCH_TYPE_GENERATE(Underlying, ...)          \
-    enum class _EnumClassForSwitchStatements : Underlying { __VA_ARGS__ };
+    enum class _enumClassForSwitchStatements : Underlying { __VA_ARGS__ };
 
 // C++98
 #define BETTER_ENUMS_CXX98_TRIM_STRINGS_ARRAYS(Enum, ...)                      \


### PR DESCRIPTION
Some identifiers are in violation of the C++ standard. Renamed by lowercasing the
offending letters. Solves #61.

Affected identifiers:

- _Iterable -> _iterable
- _PutNamesInThisScopeAlso -> _putNamesInThisScopeAlso
- _enumClassForSwitchStatements -> _enumClassForSwitchStatements