### PR TITLE
removed tabs in unwanted places

### DIFF
--- a/enum.h
+++ b/enum.h
@@ -621,8 +621,8 @@ class Enum {                                                                   \
     _from_integral_unchecked(_integral value);                                 \
     BETTER_ENUMS_CONSTEXPR_ static _optional                                   \
     _from_integral_nothrow(_integral value);                                   \
-																	     	   \
-    BETTER_ENUMS_CONSTEXPR_ std::size_t _to_index() const;   	               \
+                                                                               \
+    BETTER_ENUMS_CONSTEXPR_ std::size_t _to_index() const;                     \
     BETTER_ENUMS_IF_EXCEPTIONS(                                                \
     BETTER_ENUMS_CONSTEXPR_ static Enum _from_index(std::size_t value);        \
     )                                                                          \


### PR DESCRIPTION
2 lines had tabs in the middle of the code, between spaces. This can cause warnings in some tools and red markings in Git when commiting code (tabs are to be used only as the starting characters, never after any character).

After this commit, there are no tabs in the file at all.