### PR TITLE
Add macro for adding attributes to enum class

### DIFF
--- a/enum.h
+++ b/enum.h
@@ -608,6 +608,10 @@ constexpr const char    *_final_ ## index =                                    \
 
 #endif
 
+#ifndef BETTER_ENUMS_CLASS_ATTRIBUTE
+#   define BETTER_ENUMS_CLASS_ATTRIBUTE
+#endif
+
 #define BETTER_ENUMS_TYPE(SetUnderlyingType, SwitchType, GenerateSwitchType,   \
                           GenerateStrings, ToStringConstexpr,                  \
                           DeclareInitialize, DefineInitialize, CallInitialize, \
@@ -619,7 +623,7 @@ BETTER_ENUMS_ID(GenerateSwitchType(Underlying, __VA_ARGS__))                   \
                                                                                \
 }                                                                              \
                                                                                \
-class Enum {                                                                   \
+class BETTER_ENUMS_CLASS_ATTRIBUTE Enum {                                                                   \
   private:                                                                     \
     typedef ::better_enums::optional<Enum>                  _optional;         \
     typedef ::better_enums::optional<std::size_t>           _optional_index;   \


### PR DESCRIPTION
I think this would be a nice extension to the current framework. It is possible to add as many attributes as you like, e.g. an annotation().

In case the macro is not defined it will be defined without having any function / impact on existing code.

In our case we would like to use it for annotating better enum classes and be able to identify the classes later in a CASTXML generated document.